### PR TITLE
Add rich text description to woo product sync to meta

### DIFF
--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -46,7 +46,7 @@
 /* Match WooCommerce field hover states */
 #facebook_options .wp-editor-container:hover {
     border-color: #666;
-}bfbufrcchcciitbjlkvfikulfthcgtn
+}
 
 /* add padding-top for first radio button in variation fields */
 #woocommerce-product-data .woocommerce_variation .fb-product-image-source-field .wc-radios li:first-child {

--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -18,41 +18,6 @@
 	padding-bottom: 0;
 }
 
-/* Align the editor with other WooCommerce fields */
-#facebook_options .wp-editor-wrap {
-    padding: 5px 20px 5px 162px !important;
-    margin: 6px 0 !important;
-    position: relative;
-}
-
-/* Position the label like other WooCommerce fields */
-#facebook_options .wp-editor-wrap label {
-    float: left;
-    width: 150px;
-    padding: 0;
-    margin: 0 0 0 -150px;
-    color: #666;
-    font-size: 12px;
-    font-weight: 600;
-    line-height: 24px;
-}
-
-/* Match WooCommerce field styling */
-#facebook_options .wp-editor-container {
-    border: 1px solid #8c8f94;
-    clear: both;
-    background: #fff;
-}
-
-/* Adjust editor width to match other fields */
-#facebook_options .wp-editor-wrap {
-    max-width: calc(100% - 20px);
-}
-
-/* Style the toolbar to match WooCommerce */
-#facebook_options .mce-toolbar {
-    background: #f6f7f7;
-}
 
 /* Ensure proper spacing between fields */
 #facebook_options .options_group {
@@ -61,12 +26,6 @@
     border-bottom: 1px solid #eee;
 }
 
-/* For variation editors - apply same styles */
-.woocommerce_variable_attributes .wp-editor-wrap {
-    padding: 5px 20px 5px 162px !important;
-    margin: 6px 0 !important;
-    position: relative;
-}
 
 .woocommerce_variable_attributes .wp-editor-wrap label {
     float: left;
@@ -150,4 +109,21 @@
 /* adjusts widths of the products table, same as WooCommerce categories and tags */
 .column-facebook_sync {
 	width: 11% !important;
+}
+
+.woocommerce_options_panel .wp-editor-container {
+    margin-left: 162px;
+    width: calc(80% - 182px);
+}
+
+.woocommerce_options_panel .wp-editor-tabs {
+    margin-left: 162px;
+}
+
+/* Ensure the label aligns properly */
+.woocommerce_options_panel label[for="fb_product_description"] {
+    float: left;
+    width: 150px;
+    padding: 0;
+    margin: 0 0 0 12px;
 }

--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -18,6 +18,77 @@
 	padding-bottom: 0;
 }
 
+/* Align the editor with other WooCommerce fields */
+#facebook_options .wp-editor-wrap {
+    padding: 5px 20px 5px 162px !important;
+    margin: 6px 0 !important;
+    position: relative;
+}
+
+/* Position the label like other WooCommerce fields */
+#facebook_options .wp-editor-wrap label {
+    float: left;
+    width: 150px;
+    padding: 0;
+    margin: 0 0 0 -150px;
+    color: #666;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 24px;
+}
+
+/* Match WooCommerce field styling */
+#facebook_options .wp-editor-container {
+    border: 1px solid #8c8f94;
+    clear: both;
+    background: #fff;
+}
+
+/* Adjust editor width to match other fields */
+#facebook_options .wp-editor-wrap {
+    max-width: calc(100% - 20px);
+}
+
+/* Style the toolbar to match WooCommerce */
+#facebook_options .mce-toolbar {
+    background: #f6f7f7;
+}
+
+/* Ensure proper spacing between fields */
+#facebook_options .options_group {
+    padding: 0;
+    border-top: 1px solid #fff;
+    border-bottom: 1px solid #eee;
+}
+
+/* For variation editors - apply same styles */
+.woocommerce_variable_attributes .wp-editor-wrap {
+    padding: 5px 20px 5px 162px !important;
+    margin: 6px 0 !important;
+    position: relative;
+}
+
+.woocommerce_variable_attributes .wp-editor-wrap label {
+    float: left;
+    width: 150px;
+    padding: 0;
+    margin: 0 0 0 -150px;
+    color: #666;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 24px;
+}
+
+/* Ensure editor area has proper height */
+.wp-editor-area {
+    min-height: 100px;
+}
+
+/* Match WooCommerce field hover states */
+#facebook_options .wp-editor-container:hover {
+    border-color: #666;
+}bfbufrcchcciitbjlkvfikulfthcgtn
+
 /* add padding-top for first radio button in variation fields */
 #woocommerce-product-data .woocommerce_variation .fb-product-image-source-field .wc-radios li:first-child {
 	padding-top: 10px;

--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -111,23 +111,15 @@
 	width: 11% !important;
 }
 
-.wp-editor-container {
-    border: 1px solid #dcdcde;
-}
-
-/* Ensure the border remains visible in text mode */
-.wp-editor-container textarea.wp-editor-area {
-    border: 1px solid #dcdcde;
-    box-sizing: border-box;
-}
-
 .woocommerce_options_panel .wp-editor-container {
     margin-left: 162px;
     width: calc(100% - 182px);
+    max-width: 550px;
 }
 
 .woocommerce_options_panel .wp-editor-tabs {
     margin-left: 162px;
+    max-width: 550px;
 }
 
 /* Ensure the label aligns properly */
@@ -136,4 +128,10 @@
     width: 150px;
     padding: 0;
     margin: 0 0 0 12px;
+}
+
+/* Ensure the wp-editor-wrap takes full width */
+.wp-editor-wrap {
+    width: 100%;
+    max-width: 100%;
 }

--- a/assets/css/admin/facebook-for-woocommerce-products-admin.css
+++ b/assets/css/admin/facebook-for-woocommerce-products-admin.css
@@ -111,9 +111,19 @@
 	width: 11% !important;
 }
 
+.wp-editor-container {
+    border: 1px solid #dcdcde;
+}
+
+/* Ensure the border remains visible in text mode */
+.wp-editor-container textarea.wp-editor-area {
+    border: 1px solid #dcdcde;
+    box-sizing: border-box;
+}
+
 .woocommerce_options_panel .wp-editor-container {
     margin-left: 162px;
-    width: calc(80% - 182px);
+    width: calc(100% - 182px);
 }
 
 .woocommerce_options_panel .wp-editor-tabs {

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -853,11 +853,12 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
-			$woo_product->set_description( sanitize_text_field( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) );
+			error_log('FB Product Description POST value: ' . print_r($_POST[ self::FB_PRODUCT_DESCRIPTION ], true));
+			error_log('Sanitize ' . print_r( wp_strip_all_tags( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ), true ) , true));
+    		$woo_product->set_description( wp_strip_all_tags( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ), true ) );
 		}
 		
 		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
-			// error_log('FB Product Description POST value: ' . print_r($_POST[ self::FB_PRODUCT_DESCRIPTION ], true));
 			$woo_product->set_rich_text_description( $_POST[ self::FB_PRODUCT_DESCRIPTION ] );
 		}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -855,6 +855,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
 			$woo_product->set_description( sanitize_text_field( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) );
 		}
+		
+		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
+			error_log('FB Product Description POST value: ' . print_r($_POST[ self::FB_PRODUCT_DESCRIPTION ], true));
+			$woo_product->set_rich_text_description( $_POST[ self::FB_PRODUCT_DESCRIPTION ] );
+		}
 
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) {
 			$woo_product->set_price( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) );

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -135,7 +135,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	public const FB_PRODUCT_GROUP_ID    = 'fb_product_group_id';
 	public const FB_PRODUCT_ITEM_ID     = 'fb_product_item_id';
 	public const FB_PRODUCT_DESCRIPTION = 'fb_product_description';
-
+	public const FB_RICH_TEXT_DESCRIPTION = 'fb_rich_text_description';
 	/** @var string the API flag to set a product as visible in the Facebook shop */
 	public const FB_SHOP_PRODUCT_VISIBLE = 'published';
 
@@ -857,7 +857,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		}
 		
 		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
-			error_log('FB Product Description POST value: ' . print_r($_POST[ self::FB_PRODUCT_DESCRIPTION ], true));
+			// error_log('FB Product Description POST value: ' . print_r($_POST[ self::FB_PRODUCT_DESCRIPTION ], true));
 			$woo_product->set_rich_text_description( $_POST[ self::FB_PRODUCT_DESCRIPTION ] );
 		}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -853,8 +853,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
-			error_log('FB Product Description POST value: ' . print_r($_POST[ self::FB_PRODUCT_DESCRIPTION ], true));
-			error_log('Sanitize ' . print_r( wp_strip_all_tags( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ), true ) , true));
     		$woo_product->set_description( wp_strip_all_tags( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ), true ) );
 		}
 		

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -853,13 +853,10 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
-    		$woo_product->set_description( wp_strip_all_tags( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ), true ) );
-		}
-		
-		if ( isset( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) {
+			$woo_product->set_description( sanitize_text_field( wp_unslash( $_POST[ self::FB_PRODUCT_DESCRIPTION ] ) ) );
 			$woo_product->set_rich_text_description( $_POST[ self::FB_PRODUCT_DESCRIPTION ] );
 		}
-
+		
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) {
 			$woo_product->set_price( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) );
 		}

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1211,18 +1211,27 @@ class Admin {
 					)
 				);
 
-				woocommerce_wp_textarea_input(
+				echo '<div class="wp-editor-wrap">';
+				echo '<label for="' . esc_attr(\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION) . '">' . 
+					 esc_html__( 'Facebook Description', 'facebook-for-woocommerce' ) . 
+					 '</label>';
+				wp_editor(
+					$description,
+					\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 					array(
-						'id'          => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
-						'label'       => __( 'Facebook Description', 'facebook-for-woocommerce' ),
-						'desc_tip'    => true,
-						'description' => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
-						'cols'        => 40,
-						'rows'        => 20,
-						'value'       => $description,
-						'class'       => 'short enable-if-sync-enabled',
+						'textarea_name' => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
+						'textarea_rows' => 10,
+						'media_buttons' => false,
+						'teeny'        => true,
+						'quicktags'    => false,
+						'tinymce'      => array(
+							'toolbar1' => 'bold,italic,underline,bullist,numlist,link,unlink',
+							'toolbar2' => '',
+						),
+						'editor_css'   => '<style>.wp-editor-area{height:200px !important;}</style>',
 					)
 				);
+				echo '</div>';
 
 				woocommerce_wp_radio(
 					array(
@@ -1349,20 +1358,28 @@ class Admin {
 			)
 		);
 
-		woocommerce_wp_textarea_input(
+		// $editor_id = sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index );
+		echo '<div class="wp-editor-wrap">';
+		echo '<label for="' . esc_attr(\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION) . '">' . 
+			 esc_html__( 'Facebook Description', 'facebook-for-woocommerce' ) . 
+			 '</label>';
+		wp_editor(
+			$description,
+			\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 			array(
-				'id'            => sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index ),
-				'name'          => sprintf( "variable_%s[$index]", \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ),
-				'label'         => __( 'Facebook Description', 'facebook-for-woocommerce' ),
-				'desc_tip'      => true,
-				'description'   => __( 'Custom (plain-text only) description for product on Facebook. If blank, product description will be used. If product description is blank, shortname will be used.', 'facebook-for-woocommerce' ),
-				'cols'          => 40,
-				'rows'          => 5,
-				'value'         => $description,
-				'class'         => 'enable-if-sync-enabled',
-				'wrapper_class' => 'form-row form-row-full',
+				'textarea_name' => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
+				'textarea_rows' => 10,
+				'media_buttons' => false,
+				'teeny'        => true,
+				'quicktags'    => false,
+				'tinymce'      => array(
+					'toolbar1' => 'bold,italic,underline,bullist,numlist,link,unlink',
+					'toolbar2' => '',
+				),
+				'editor_css'   => '<style>.wp-editor-area{height:200px !important;}</style>',
 			)
 		);
+		echo '</div>';
 
 		woocommerce_wp_radio(
 			array(

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1219,16 +1219,16 @@ class Admin {
 					$description,
 					\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 					array(
+						'id'      => 'wc_facebook_sync_mode',
 						'textarea_name' => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 						'textarea_rows' => 10,
-						'media_buttons' => false,
+						'media_buttons' => true,
 						'teeny'        => true,
 						'quicktags'    => false,
 						'tinymce'      => array(
-							'toolbar1' => 'bold,italic,underline,bullist,numlist,link,unlink',
-							'toolbar2' => '',
+							'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen,wp_adv',
+							'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help'
 						),
-						'editor_css'   => '<style>.wp-editor-area{height:200px !important;}</style>',
 					)
 				);
 				echo '</div>';
@@ -1369,15 +1369,14 @@ class Admin {
 			array(
 				'textarea_name' => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 				'textarea_rows' => 10,
-				'media_buttons' => false,
+				'media_buttons' => true,
 				'teeny'        => true,
 				'quicktags'    => false,
 				'tinymce'      => array(
-					'toolbar1' => 'bold,italic,underline,bullist,numlist,link,unlink',
-					'toolbar2' => '',
+					'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen,wp_adv',
+					'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help'
 				),
-				'editor_css'   => '<style>.wp-editor-area{height:200px !important;}</style>',
-			)
+				)
 		);
 		echo '</div>';
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1365,7 +1365,6 @@ class Admin {
 			)
 		);
 
-		// $editor_id = sprintf( 'variable_%s%s', \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $index );
 		echo '<div class="wp-editor-wrap">';
 		echo '<label for="' . esc_attr(\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION) . '">' . 
 			 esc_html__( 'Facebook Description', 'facebook-for-woocommerce' ) . 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1181,7 +1181,6 @@ class Admin {
 		$is_visible   = ( $visibility = get_post_meta( $post->ID, Products::VISIBILITY_META_KEY, true ) ) ? wc_string_to_bool( $visibility ) : true;
 		$product 	  = wc_get_product( $post );
 
-		$description  = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, true );
 		$rich_text_description  = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, true );
 		$price        = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_PRICE, true );
 		$image_source = get_post_meta( $post->ID, Products::PRODUCT_IMAGE_SOURCE_META_KEY, true );

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1227,14 +1227,9 @@ class Admin {
 						'textarea_rows' => 10,
 						'media_buttons' => true,
 						'teeny'        => true,
-						'quicktags'    => true,
+						'quicktags'    => false,
 						'tinymce'      => array(
 							'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen',
-							'entity_encoding' => 'named',
-							'verify_html' => false,
-							'preserve_newlines' => true,
-							'entities' => '160,nbsp,38,amp,60,lt,62,gt',
-							'cleanup' => false,
 						),
 					)
 				);
@@ -1340,7 +1335,6 @@ class Admin {
 		$sync_enabled = 'no' !== $this->get_product_variation_meta( $variation, Products::SYNC_ENABLED_META_KEY, $parent );
 		$is_visible   = ( $visibility = $this->get_product_variation_meta( $variation, Products::VISIBILITY_META_KEY, $parent ) ) ? wc_string_to_bool( $visibility ) : true;
 
-		$description  = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $parent );
 		$rich_text_description  = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, $parent );
 		$price        = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_PRICE, $parent );
 		$image_url    = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_IMAGE, $parent );
@@ -1375,21 +1369,16 @@ class Admin {
 			 esc_html__( 'Facebook Description', 'facebook-for-woocommerce' ) . 
 			 '</label>';
 		wp_editor(
-			$description,
+			$rich_text_description,
 			\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 			array(
 				'textarea_name' => \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 				'textarea_rows' => 10,
 				'media_buttons' => true,
 				'teeny'        => true,
-				'quicktags'    => true,
+				'quicktags'    => false,
 				'tinymce'      => array(
 					'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen',
-					'entity_encoding' => 'named',
-					'verify_html' => false,
-					'preserve_newlines' => true,
-					'entities' => '160,nbsp,38,amp,60,lt,62,gt',
-					'cleanup' => false,
 				),
 			)
 		);

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1182,6 +1182,7 @@ class Admin {
 		$product 	  = wc_get_product( $post );
 
 		$description  = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, true );
+		$rich_text_description  = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, true );
 		$price        = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_PRICE, true );
 		$image_source = get_post_meta( $post->ID, Products::PRODUCT_IMAGE_SOURCE_META_KEY, true );
 		$image        = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_IMAGE, true );
@@ -1216,7 +1217,7 @@ class Admin {
 					 esc_html__( 'Facebook Description', 'facebook-for-woocommerce' ) . 
 					 '</label>';
 				wp_editor(
-					$description,
+					$rich_text_description,
 					\WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION,
 					array(
 						'id'      => 'wc_facebook_sync_mode',
@@ -1224,10 +1225,15 @@ class Admin {
 						'textarea_rows' => 10,
 						'media_buttons' => true,
 						'teeny'        => true,
-						'quicktags'    => false,
+						'quicktags'    => true,
 						'tinymce'      => array(
 							'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen,wp_adv',
-							'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help'
+							'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help',
+							'entity_encoding' => 'named',
+							'verify_html' => false,
+							'preserve_newlines' => true,
+							'entities' => '160,nbsp,38,amp,60,lt,62,gt',
+							'cleanup' => false,
 						),
 					)
 				);
@@ -1332,6 +1338,7 @@ class Admin {
 		$is_visible   = ( $visibility = $this->get_product_variation_meta( $variation, Products::VISIBILITY_META_KEY, $parent ) ) ? wc_string_to_bool( $visibility ) : true;
 
 		$description  = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, $parent );
+		$rich_text_description  = $this->get_product_variation_meta( $variation, \WC_Facebookcommerce_Integration::FB_RICH_TEXT_DESCRIPTION, $parent );
 		$price        = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_PRICE, $parent );
 		$image_url    = $this->get_product_variation_meta( $variation, \WC_Facebook_Product::FB_PRODUCT_IMAGE, $parent );
 		$image_source = $variation->get_meta( Products::PRODUCT_IMAGE_SOURCE_META_KEY );
@@ -1371,12 +1378,17 @@ class Admin {
 				'textarea_rows' => 10,
 				'media_buttons' => true,
 				'teeny'        => true,
-				'quicktags'    => false,
+				'quicktags'    => true,
 				'tinymce'      => array(
 					'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen,wp_adv',
-					'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help'
+					'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help',
+					'entity_encoding' => 'named',
+					'verify_html' => false,
+					'preserve_newlines' => true,
+					'entities' => '160,nbsp,38,amp,60,lt,62,gt',
+					'cleanup' => false,
 				),
-				)
+			)
 		);
 		echo '</div>';
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1229,8 +1229,7 @@ class Admin {
 						'teeny'        => true,
 						'quicktags'    => true,
 						'tinymce'      => array(
-							'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen,wp_adv',
-							'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help',
+							'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen',
 							'entity_encoding' => 'named',
 							'verify_html' => false,
 							'preserve_newlines' => true,
@@ -1385,8 +1384,7 @@ class Admin {
 				'teeny'        => true,
 				'quicktags'    => true,
 				'tinymce'      => array(
-					'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen,wp_adv',
-					'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help',
+					'toolbar1' => 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,spellchecker,fullscreen',
 					'entity_encoding' => 'named',
 					'verify_html' => false,
 					'preserve_newlines' => true,

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -47,7 +47,7 @@ class Enhanced_Catalog_Attribute_Fields {
 	 */
 	private $category_handler;
 
-	public function __construct( $page_type, \WP_Term $term = null, \WC_Product $product = null ) {
+	public function __construct( $page_type, ?\WP_Term $term = null, ?\WC_Product $product = null ) {
 		$this->page_type        = $page_type;
 		$this->term             = $term;
 		$this->product          = $product;

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -368,10 +368,14 @@ class WC_Facebook_Product {
 	}
 
 	public function set_rich_text_description( $rich_text_description ) {
-		$rich_text_description          = stripslashes(
-			WC_Facebookcommerce_Utils::clean_string( $rich_text_description, false )
-		);
+		$rich_text_description          = 
+			WC_Facebookcommerce_Utils::clean_string( $rich_text_description, false );
 		$this->rich_text_description = $rich_text_description;
+		update_post_meta(
+			$this->id,
+			self::FB_RICH_TEXT_DESCRIPTION,
+			$rich_text_description
+		);
 	}
 
 	public function set_price( $price ) {
@@ -481,7 +485,7 @@ class WC_Facebook_Product {
 			// Try to get description from post meta if fb description has been set
 			$rich_text_description = get_post_meta(
 				$this->id,
-				self::FB_PRODUCT_DESCRIPTION,
+				self::FB_RICH_TEXT_DESCRIPTION,
 				true
 			);
 			if ($rich_text_description){
@@ -727,7 +731,7 @@ class WC_Facebook_Product {
 
 		$rich_text_description = $this->get_rich_text_description();
 		
-		print_r('source', self::$rich_text_description_source);
+		// print_r('source', self::$rich_text_description_source);
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
 			$product_data = array_merge(
@@ -743,8 +747,9 @@ class WC_Facebook_Product {
 				'price'                 => $this->get_fb_price( true ),
 				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
+				'rich_text_description' => $rich_text_description
 			),
-			self::$rich_text_description_source === WC_Facebookcommerce_Utils::WOO_DESCRIPTION ? array('rich_text_description' => $rich_text_description) : array()
+			// self::$rich_text_description_source === WC_Facebookcommerce_Utils::WOO_DESCRIPTION ? array('rich_text_description' => $rich_text_description) : array('rich_text_description' => $rich_text_description)
 		);
 			$product_data   = $this->add_sale_price( $product_data, true );
 			$gpc_field_name = 'google_product_category';

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -67,6 +67,12 @@ class WC_Facebook_Product {
 	 */
 	private $fb_description;
 
+
+	/**
+	 * @var string Facebook Rich Text Description.
+	 */
+	private $fb_rich_text_description;
+
 	/**
 	 * @var array Gallery URLs.
 	 */
@@ -347,11 +353,22 @@ class WC_Facebook_Product {
 		$description          = stripslashes(
 			WC_Facebookcommerce_Utils::clean_string( $description )
 		);
+		$rich_text_description          = stripslashes(
+			WC_Facebookcommerce_Utils::clean_string( $description, false )
+		);
 		$this->fb_description = $description;
+		$this->fb_rich_text_description = $rich_text_description;
+
 		update_post_meta(
 			$this->id,
 			self::FB_PRODUCT_DESCRIPTION,
 			$description
+		);
+
+		update_post_meta(
+			$this->id,
+			self::FB_RICH_TEXT_DESCRIPTION,
+			$rich_text_description
 		);
 	}
 
@@ -483,20 +500,23 @@ class WC_Facebook_Product {
 
 		if ( empty( $rich_text_description ) ) {
 			// Try to get description from post meta if fb description has been set
-			$rich_text_description = get_post_meta(
+			$temp_rich_text_description = get_post_meta(
 				$this->id,
+				self::FB_RICH_TEXT_DESCRIPTION,
 				self::FB_RICH_TEXT_DESCRIPTION,
 				true
 			);
-			if ($rich_text_description){
+
+			if ($temp_rich_text_description){
                 self::$rich_text_description_source = WC_Facebookcommerce_Utils::FB_DESCRIPTION;
+				$rich_text_description = $temp_rich_text_description;
             }
 		}
 
 		// For variable products, we want to use the rich text description of the variant.
 		// If that's not available, fall back to the main (parent) product's rich text description.
 		if (empty($rich_text_description) && WC_Facebookcommerce_Utils::is_variation_type($this->woo_product->get_type())) {
-			$rich_text_description = WC_Facebookcommerce_Utils::clean_string($this->woo_product->get_rich_text_description());
+			$rich_text_description = WC_Facebookcommerce_Utils::clean_string($this->woo_product->get_description(), false);
 
 			// If the variant's rich text description is still empty, use the main product's rich text description as a fallback.
 			if (empty($rich_text_description) && $this->main_description) {

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -44,8 +44,7 @@ class WC_Facebook_Product {
 	const MIN_TIME   = 'T00:00+00:00';
 
 	public static $rich_text_description_source = WC_Facebookcommerce_Utils::WC_DESCRIPTION;
-
-	static $use_checkout_url = array(
+	static $use_checkout_url                    = array(
 		'simple'    => 1,
 		'variable'  => 1,
 		'variation' => 1,
@@ -132,6 +131,7 @@ class WC_Facebook_Product {
 			$this->gallery_urls        = $parent_product->get_gallery_urls();
 			$this->fb_use_parent_image = $parent_product->get_use_parent_image();
 			$this->main_description    = $parent_product->get_fb_description();
+			$this->rich_text_description = $parent_product->get_rich_text_description();
 		}
 	}
 
@@ -349,29 +349,12 @@ class WC_Facebook_Product {
 	}
 
 	public function set_description( $description ) {
-		$rich_text_description          = stripslashes(
-			WC_Facebookcommerce_Utils::clean_string( $description, false )
-		);
-
-		$description          = stripslashes(
-			WC_Facebookcommerce_Utils::clean_string( $description )
-		);
-		
-		error_log('FB Product Description SET value: ' . print_r($description, true));
-
-		$this->fb_description = $rich_text_description;
-		$this->fb_rich_text_description = $rich_text_description;
-
+		$description          = stripslashes( WC_Facebookcommerce_Utils::clean_string( $description ) );
+		$this->fb_description = $description;
 		update_post_meta(
 			$this->id,
 			self::FB_PRODUCT_DESCRIPTION,
 			$description
-		);
-
-		update_post_meta(
-			$this->id,
-			self::FB_RICH_TEXT_DESCRIPTION,
-			$rich_text_description
 		);
 	}
 
@@ -388,7 +371,7 @@ class WC_Facebook_Product {
 	}
 
 	public function set_rich_text_description( $rich_text_description ) {
-		$rich_text_description          = 
+		$rich_text_description       =
 			WC_Facebookcommerce_Utils::clean_string( $rich_text_description, false );
 		$this->rich_text_description = $rich_text_description;
 		update_post_meta(
@@ -423,7 +406,7 @@ class WC_Facebook_Product {
 	}
 
 	public function set_use_parent_image( $setting ) {
-		$this->fb_use_parent_image = ( $setting == 'yes' );
+		$this->fb_use_parent_image = ( $setting === 'yes' );
 		update_post_meta(
 			$this->id,
 			self::FB_VARIANT_IMAGE,
@@ -491,68 +474,67 @@ class WC_Facebook_Product {
 	/**
 	 * Get the rich text description for a product.
 	 *
-	 * This function determines the preferred product description based on the following logic:
-	 * 1. Check if the rich text description is available and not empty.
+	 * This function retrieves the rich text product description based on the following logic:
+	 * 1. Check if the facebook rich text description is set and not empty.
 	 * 2. If the rich text description is available, use it as the preferred description.
-	 * 3. Otherwise, fall back to the plain text description.
+	 * 3. Otherwise, fall back to the plain text description made available by Woocommerce.
 	 *
 	 * @return string The rich text description for the product.
 	 */
 	public function get_rich_text_description() {
 		$rich_text_description = '';
 
-			// Check if the fb description is set as that takes preference.
+		// Check if the fb description is set as that takes preference
 		if ( $this->fb_description ) {
-				$rich_text_description = $this->fb_description;
+			$rich_text_description = $this->fb_description;
 		}
 
-			// If the rich text description is available, use it as the preferred description.
+		// If the rich text description is available, use it as the preferred description
 		if ( $this->rich_text_description ) {
-				$rich_text_description = $this->rich_text_description;
+			$rich_text_description = $this->rich_text_description;
 		}
 
-			// If no description is found from meta or variation, get from post
+		// Try to get description from post meta if fb description has been set
 		if ( empty( $rich_text_description ) ) {
-			// Try to get description from post meta if fb description has been set
 			$temp_rich_text_description = get_post_meta(
 				$this->id,
 				self::FB_RICH_TEXT_DESCRIPTION,
 				true
 			);
 
-			if ($temp_rich_text_description){
-                self::$rich_text_description_source = WC_Facebookcommerce_Utils::FB_DESCRIPTION;
-				$rich_text_description = $temp_rich_text_description;
-            }
+			if ( $temp_rich_text_description ) {
+				self::$rich_text_description_source = WC_Facebookcommerce_Utils::FB_DESCRIPTION;
+				$rich_text_description              = $temp_rich_text_description;
+			}
 		}
 
 		// For variable products, we want to use the rich text description of the variant.
 		// If that's not available, fall back to the main (parent) product's rich text description.
-		if (empty($rich_text_description) && WC_Facebookcommerce_Utils::is_variation_type($this->woo_product->get_type())) {
-			$rich_text_description = WC_Facebookcommerce_Utils::clean_string($this->woo_product->get_description(), false);
+		if ( empty( $rich_text_description ) && WC_Facebookcommerce_Utils::is_variation_type( $this->woo_product->get_type() ) ) {
+			$rich_text_description = WC_Facebookcommerce_Utils::clean_string( $this->woo_product->get_description(), false );
 
-				// If the variant's rich text description is still empty, use the main product's rich text description as a fallback.
+			// If the variant's rich text description is still empty, use the main product's rich text description as a fallback
 			if ( empty( $rich_text_description ) && $this->main_description ) {
-					$rich_text_description = $this->rich_text_description;
+				$rich_text_description = $this->main_description;
 			}
 		}
 
-			// If no description is found from meta or variation, get from post
+		// If no description is found from meta or variation, get from post
 		if ( empty( $rich_text_description ) ) {
-				$post         = $this->get_post_data();
-				$post_content = WC_Facebookcommerce_Utils::clean_string( $post->post_content, false );
-				$post_excerpt = WC_Facebookcommerce_Utils::clean_string( $post->post_excerpt, false );
+			$post         = $this->get_post_data();
+			$post_content = WC_Facebookcommerce_Utils::clean_string( $post->post_content, false );
+			$post_excerpt = WC_Facebookcommerce_Utils::clean_string( $post->post_excerpt, false );
 
 			if ( ! empty( $post_content ) ) {
-					$rich_text_description = $post_content;
+				$rich_text_description = $post_content;
 			}
 
 			if ( $this->sync_short_description || ( empty( $rich_text_description ) && ! empty( $post_excerpt ) ) ) {
-					$rich_text_description = $post_excerpt;
+				$rich_text_description = $post_excerpt;
 			}
 		}
 
-			return apply_filters( 'facebook_for_woocommerce_fb_rich_text_description', $rich_text_description, $this->id );
+		return apply_filters( 'facebook_for_woocommerce_fb_rich_text_description', $rich_text_description, $this->id );
 	}
 
 	/**
@@ -778,7 +760,6 @@ class WC_Facebook_Product {
 					'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 				),
-				// self::$rich_text_description_source === WC_Facebookcommerce_Utils::WC_DESCRIPTION ? array( 'rich_text_description' => $rich_text_description ) : array()
 			);
 			$product_data   = $this->add_sale_price( $product_data, true );
 			$gpc_field_name = 'google_product_category';
@@ -813,7 +794,6 @@ class WC_Facebook_Product {
 					'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 				),
-				// self::$rich_text_description_source === WC_Facebookcommerce_Utils::WC_DESCRIPTION ? array( 'rich_text_description' => $rich_text_description ) : array()
 			);
 
 			if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && ! empty( $video_urls ) ) {

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -486,16 +486,13 @@ class WC_Facebook_Product {
 		$rich_text_description = '';
 
 		// Check if the fb description is set as that takes preference
-		if ( $this->fb_description ) {
+		if ( $this->rich_text_description ) {
+			$rich_text_description = $this->rich_text_description;
+		} elseif ( $this->fb_description ) {
 			$rich_text_description = $this->fb_description;
 		}
 
-		// If the rich text description is available, use it as the preferred description
-		if ( $this->rich_text_description ) {
-			$rich_text_description = $this->rich_text_description;
-		}
-
-		// Try to get description from post meta if fb description has been set
+		// Try to get rich text description from post meta if description has been set
 		if ( empty( $rich_text_description ) ) {
 			$temp_rich_text_description = get_post_meta(
 				$this->id,

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -29,12 +29,12 @@ class WC_Facebook_Product {
 
 	// Should match facebook-commerce.php while we migrate that code over
 	// to this object.
-	const FB_PRODUCT_DESCRIPTION = 'fb_product_description';
-	const FB_PRODUCT_PRICE       = 'fb_product_price';
-	const FB_PRODUCT_IMAGE       = 'fb_product_image';
-	const FB_VARIANT_IMAGE       = 'fb_image';
-	const FB_VISIBILITY          = 'fb_visibility';
-	const FB_REMOVE_FROM_SYNC    = 'fb_remove_from_sync';
+	const FB_PRODUCT_DESCRIPTION   = 'fb_product_description';
+	const FB_PRODUCT_PRICE         = 'fb_product_price';
+	const FB_PRODUCT_IMAGE         = 'fb_product_image';
+	const FB_VARIANT_IMAGE         = 'fb_image';
+	const FB_VISIBILITY            = 'fb_visibility';
+	const FB_REMOVE_FROM_SYNC      = 'fb_remove_from_sync';
 	const FB_RICH_TEXT_DESCRIPTION = 'fb_rich_text_description';
 
 	const MIN_DATE_1 = '1970-01-29';
@@ -43,8 +43,7 @@ class WC_Facebook_Product {
 	const MAX_TIME   = 'T23:59+00:00';
 	const MIN_TIME   = 'T00:00+00:00';
 
-    public static $rich_text_description_source = WC_Facebookcommerce_Utils::WOO_DESCRIPTION;
-	
+	public static $rich_text_description_source = WC_Facebookcommerce_Utils::WC_DESCRIPTION;
 
 	static $use_checkout_url = array(
 		'simple'    => 1,
@@ -109,8 +108,8 @@ class WC_Facebook_Product {
 			$this->id          = $wpid->get_id();
 			$this->woo_product = $wpid;
 		} else {
-			$this->id                     = $wpid;
-			$this->woo_product            = wc_get_product( $wpid );
+			$this->id          = $wpid;
+			$this->woo_product = wc_get_product( $wpid );
 		}
 
 		$this->fb_description         = '';
@@ -250,7 +249,7 @@ class WC_Facebook_Product {
 		 * @param string $size The image size. e.g. 'full', 'medium', 'thumbnail'.
 		 */
 		$image_size               = apply_filters( 'facebook_for_woocommerce_fb_product_image_size', 'full' );
-		$product_image_url        = wp_get_attachment_image_url( $this->woo_product->get_image_id(), $image_size ); ;
+		$product_image_url        = wp_get_attachment_image_url( $this->woo_product->get_image_id(), $image_size );
 		$parent_product_image_url = null;
 		$custom_image_url         = $this->woo_product->get_meta( self::FB_PRODUCT_IMAGE );
 
@@ -316,7 +315,7 @@ class WC_Facebook_Product {
 					)
 				);
 			}
-        }
+		}
 
 		return $video_urls;
 	}
@@ -485,19 +484,30 @@ class WC_Facebook_Product {
 		return apply_filters( 'facebook_for_woocommerce_fb_product_description', $description, $this->id );
 	}
 
+	/**
+	 * Get the rich text description for a product.
+	 *
+	 * This function determines the preferred product description based on the following logic:
+	 * 1. Check if the rich text description is available and not empty.
+	 * 2. If the rich text description is available, use it as the preferred description.
+	 * 3. Otherwise, fall back to the plain text description.
+	 *
+	 * @return string The rich text description for the product.
+	 */
 	public function get_rich_text_description() {
 		$rich_text_description = '';
 
+			// Check if the fb description is set as that takes preference.
 		if ( $this->fb_description ) {
-			$rich_text_description = $this->fb_description;
+				$rich_text_description = $this->fb_description;
 		}
 
+			// If the rich text description is available, use it as the preferred description.
 		if ( $this->rich_text_description ) {
-			$rich_text_description = $this->rich_text_description;
+				$rich_text_description = $this->rich_text_description;
 		}
-		
-		
 
+			// If no description is found from meta or variation, get from post
 		if ( empty( $rich_text_description ) ) {
 			// Try to get description from post meta if fb description has been set
 			$temp_rich_text_description = get_post_meta(
@@ -518,41 +528,39 @@ class WC_Facebook_Product {
 		if (empty($rich_text_description) && WC_Facebookcommerce_Utils::is_variation_type($this->woo_product->get_type())) {
 			$rich_text_description = WC_Facebookcommerce_Utils::clean_string($this->woo_product->get_description(), false);
 
-			// If the variant's rich text description is still empty, use the main product's rich text description as a fallback.
-			if (empty($rich_text_description) && $this->main_description) {
-				$rich_text_description = $this->rich_text_description;
+				// If the variant's rich text description is still empty, use the main product's rich text description as a fallback.
+			if ( empty( $rich_text_description ) && $this->main_description ) {
+					$rich_text_description = $this->rich_text_description;
 			}
 		}
 
-		// If no description is found from meta or variation, get from post
+			// If no description is found from meta or variation, get from post
 		if ( empty( $rich_text_description ) ) {
-			$post         = $this->get_post_data();
-			$post_content = WC_Facebookcommerce_Utils::clean_string( $post->post_content, false );
-			$post_excerpt = WC_Facebookcommerce_Utils::clean_string( $post->post_excerpt, false );
+				$post         = $this->get_post_data();
+				$post_content = WC_Facebookcommerce_Utils::clean_string( $post->post_content, false );
+				$post_excerpt = WC_Facebookcommerce_Utils::clean_string( $post->post_excerpt, false );
 
-			
 			if ( ! empty( $post_content ) ) {
-				$rich_text_description = $post_content;
+					$rich_text_description = $post_content;
 			}
 
 			if ( $this->sync_short_description || ( empty( $rich_text_description ) && ! empty( $post_excerpt ) ) ) {
-				$rich_text_description = $post_excerpt;
+					$rich_text_description = $post_excerpt;
 			}
-
 		}
-		
-		return apply_filters( 'facebook_for_woocommerce_fb_rich_text_description', $rich_text_description, $this->id );
+
+			return apply_filters( 'facebook_for_woocommerce_fb_rich_text_description', $rich_text_description, $this->id );
 	}
 
 	/**
 	 * @param array $product_data
-	 * @param bool $for_items_batch
+	 * @param bool  $for_items_batch
 	 *
 	 * @return array
 	 */
 	public function add_sale_price( $product_data, $for_items_batch = false ) {
 
-		$sale_price = $this->woo_product->get_sale_price();
+		$sale_price                = $this->woo_product->get_sale_price();
 		$sale_price_effective_date = '';
 
 		$sale_start =
@@ -568,14 +576,14 @@ class WC_Facebook_Product {
 		// check if sale exist
 		if ( is_numeric( $sale_price ) && $sale_price > 0 ) {
 			$sale_price_effective_date = $sale_start . '/' . $sale_end;
-			$sale_price =
+			$sale_price                =
 				intval( round( $this->get_price_plus_tax( $sale_price ) * 100 ) );
 		}
 
 		// check if sale is expired and sale time range is valid
 		if ( $for_items_batch ) {
 			$product_data['sale_price_effective_date'] = $sale_price_effective_date;
-			$product_data['sale_price']                = is_numeric( $sale_price ) ? self::format_price_for_fb_items_batch( $sale_price ) : "";
+			$product_data['sale_price']                = is_numeric( $sale_price ) ? self::format_price_for_fb_items_batch( $sale_price ) : '';
 		} else {
 			$product_data['sale_price_start_date'] = $sale_start;
 			$product_data['sale_price_end_date']   = $sale_end;
@@ -595,12 +603,12 @@ class WC_Facebook_Product {
 				'price' => $price,
 			);
 			return get_option( 'woocommerce_tax_display_shop' ) === 'incl'
-				  ? wc_get_price_including_tax( $woo_product, $args )
-				  : wc_get_price_excluding_tax( $woo_product, $args );
+					? wc_get_price_including_tax( $woo_product, $args )
+					: wc_get_price_excluding_tax( $woo_product, $args );
 		} else {
 			return get_option( 'woocommerce_tax_display_shop' ) === 'incl'
-				  ? $woo_product->get_price_including_tax( 1, $price )
-				  : $woo_product->get_price_excluding_tax( 1, $price );
+					? $woo_product->get_price_including_tax( 1, $price )
+					: $woo_product->get_price_excluding_tax( 1, $price );
 		}
 	}
 
@@ -738,39 +746,36 @@ class WC_Facebook_Product {
 		WC_Facebookcommerce_Utils::get_product_categories( $id );
 
 		// Get brand attribute.
-		$brand = get_post_meta( $id, Products::ENHANCED_CATALOG_ATTRIBUTES_META_KEY_PREFIX . 'brand', true );
+		$brand          = get_post_meta( $id, Products::ENHANCED_CATALOG_ATTRIBUTES_META_KEY_PREFIX . 'brand', true );
 		$brand_taxonomy = get_the_term_list( $id, 'product_brand', '', ', ' );
 
 		if ( $brand ) {
 			$brand = WC_Facebookcommerce_Utils::clean_string( $brand );
-		} elseif ( !is_wp_error( $brand_taxonomy ) && $brand_taxonomy ) {
+		} elseif ( ! is_wp_error( $brand_taxonomy ) && $brand_taxonomy ) {
 			$brand = WC_Facebookcommerce_Utils::clean_string( $brand_taxonomy );
 		} else {
 			$brand = wp_strip_all_tags( WC_Facebookcommerce_Utils::get_store_name() );
 		}
 
 		$rich_text_description = $this->get_rich_text_description();
-		
-		// print_r('source', self::$rich_text_description_source);
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
-			$product_data = array_merge(
-			array(
-				'title'                 => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
-				'description'           => $this->get_fb_description(),
-				'image_link'            => $image_urls[0],
-				'additional_image_link' => $this->get_additional_image_urls( $image_urls ),
-				'link'                  => $product_url,
-				'product_type'          => $categories['categories'],
-				'brand'                 => Helper::str_truncate( $brand, 100 ),
-				'retailer_id'           => $retailer_id,
-				'price'                 => $this->get_fb_price( true ),
-				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
-				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
-				'rich_text_description' => $rich_text_description
-			),
-			// self::$rich_text_description_source === WC_Facebookcommerce_Utils::WOO_DESCRIPTION ? array('rich_text_description' => $rich_text_description) : array('rich_text_description' => $rich_text_description)
-		);
+			$product_data   = array_merge(
+				array(
+					'title'                 => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
+					'description'           => $this->get_fb_description(),
+					'image_link'            => $image_urls[0],
+					'additional_image_link' => $this->get_additional_image_urls( $image_urls ),
+					'link'                  => $product_url,
+					'product_type'          => $categories['categories'],
+					'brand'                 => Helper::str_truncate( $brand, 100 ),
+					'retailer_id'           => $retailer_id,
+					'price'                 => $this->get_fb_price( true ),
+					'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
+					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
+				),
+				self::$rich_text_description_source === WC_Facebookcommerce_Utils::WC_DESCRIPTION ? array( 'rich_text_description' => $rich_text_description ) : array()
+			);
 			$product_data   = $this->add_sale_price( $product_data, true );
 			$gpc_field_name = 'google_product_category';
 			if ( ! empty( $video_urls ) ) {
@@ -779,32 +784,32 @@ class WC_Facebook_Product {
 		} else {
 			$product_data = array_merge(
 				array(
-				'name'                  => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
-				'description'           => $this->get_fb_description(),
-				'image_url'             => $image_urls[0],
-				'additional_image_urls' => $this->get_additional_image_urls( $image_urls ),
-				'url'                   => $product_url,
-				/**
-				 * 'category' is a required field for creating a ProductItem object when posting to /{product_catalog_id}/products.
-				 * This field should have the Google product category for the item. Google product category is not a required field
-				 * in the WooCommerce product editor. Hence, we are setting 'category' to Woo product categories by default and overriding
-				 * it when a Google product category is set.
-				 *
-				 * @see https://developers.facebook.com/docs/marketing-api/reference/product-catalog/products/#parameters-2
-				 * @see https://github.com/woocommerce/facebook-for-woocommerce/pull/2575
-				 * @see https://github.com/woocommerce/facebook-for-woocommerce/issues/2593
-				 */
-				'category'              => $categories['categories'],
-				'product_type'          => $categories['categories'],
-				'brand'                 => Helper::str_truncate( $brand, 100 ),
-				'retailer_id'           => $retailer_id,
-				'price'                 => $this->get_fb_price(),
-				'currency'              => get_woocommerce_currency(),
-				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
-				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
-			),
-			self::$rich_text_description_source === WC_Facebookcommerce_Utils::WOO_DESCRIPTION ? array('rich_text_description' => $rich_text_description) : array()
-		);
+					'name'                  => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
+					'description'           => $this->get_fb_description(),
+					'image_url'             => $image_urls[0],
+					'additional_image_urls' => $this->get_additional_image_urls( $image_urls ),
+					'url'                   => $product_url,
+					/**
+					 * 'category' is a required field for creating a ProductItem object when posting to /{product_catalog_id}/products.
+					 * This field should have the Google product category for the item. Google product category is not a required field
+					 * in the WooCommerce product editor. Hence, we are setting 'category' to Woo product categories by default and overriding
+					 * it when a Google product category is set.
+					 *
+					 * @see https://developers.facebook.com/docs/marketing-api/reference/product-catalog/products/#parameters-2
+					 * @see https://github.com/woocommerce/facebook-for-woocommerce/pull/2575
+					 * @see https://github.com/woocommerce/facebook-for-woocommerce/issues/2593
+					 */
+					'category'              => $categories['categories'],
+					'product_type'          => $categories['categories'],
+					'brand'                 => Helper::str_truncate( $brand, 100 ),
+					'retailer_id'           => $retailer_id,
+					'price'                 => $this->get_fb_price(),
+					'currency'              => get_woocommerce_currency(),
+					'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
+					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
+				),
+				self::$rich_text_description_source === WC_Facebookcommerce_Utils::WC_DESCRIPTION ? array( 'rich_text_description' => $rich_text_description ) : array()
+			);
 
 			if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && ! empty( $video_urls ) ) {
 				$product_data['video'] = $video_urls;
@@ -846,9 +851,9 @@ class WC_Facebook_Product {
 			// No Visibility Option for Variations
 			// get_virtual() returns true for "unassembled bundles", so we exclude
 			// bundles from this check.
-			if ( true === $this->get_virtual() && 'bundle' !== $this->get_type() ) {
-				$product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
-			}
+		if ( true === $this->get_virtual() && 'bundle' !== $this->get_type() ) {
+			$product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
+		}
 
 		if ( self::PRODUCT_PREP_TYPE_FEED !== $type_to_prepare_for ) {
 			$this->prepare_variants_for_item( $product_data );
@@ -860,11 +865,11 @@ class WC_Facebook_Product {
 		}
 
 		/**
-		   * Filters the generated product data.
-		   *
-		   * @param int   $id           Woocommerce product id
-		   * @param array $product_data An array of product data
-		   */
+			* Filters the generated product data.
+			*
+			* @param int   $id           Woocommerce product id
+			* @param array $product_data An array of product data
+			*/
 		return apply_filters(
 			'facebook_for_woocommerce_integration_prepare_product',
 			$product_data,
@@ -882,7 +887,7 @@ class WC_Facebook_Product {
 	 * @return array
 	 */
 	private function apply_enhanced_catalog_fields_from_attributes( $product_data, $google_category_id ) {
-		$category_handler   = facebook_for_woocommerce()->get_facebook_category_handler();
+		$category_handler = facebook_for_woocommerce()->get_facebook_category_handler();
 		if ( empty( $google_category_id ) || ! $category_handler->is_category( $google_category_id ) ) {
 			return $product_data;
 		}
@@ -923,7 +928,7 @@ class WC_Facebook_Product {
 	public function get_matched_attributes_for_product( $product, $all_attributes ) {
 		$matched_attributes = array();
 		$sanitized_keys     = array_map(
-			function( $key ) {
+			function ( $key ) {
 					return \WC_Facebookcommerce_Utils::sanitize_variant_name( $key, false );
 			},
 			array_keys( $product->get_attributes() )
@@ -931,7 +936,7 @@ class WC_Facebook_Product {
 
 		$matched_attributes = array_filter(
 			$all_attributes,
-			function( $attribute ) use ( $sanitized_keys ) {
+			function ( $attribute ) use ( $sanitized_keys ) {
 				return in_array( $attribute['key'], $sanitized_keys );
 			}
 		);
@@ -1150,6 +1155,4 @@ class WC_Facebook_Product {
 
 		return $final_variants;
 	}
-
-
 }

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -349,13 +349,17 @@ class WC_Facebook_Product {
 	}
 
 	public function set_description( $description ) {
-		$description          = stripslashes(
-			WC_Facebookcommerce_Utils::clean_string( $description )
-		);
 		$rich_text_description          = stripslashes(
 			WC_Facebookcommerce_Utils::clean_string( $description, false )
 		);
-		$this->fb_description = $description;
+
+		$description          = stripslashes(
+			WC_Facebookcommerce_Utils::clean_string( $description )
+		);
+		
+		error_log('FB Product Description SET value: ' . print_r($description, true));
+
+		$this->fb_description = $rich_text_description;
 		$this->fb_rich_text_description = $rich_text_description;
 
 		update_post_meta(
@@ -512,7 +516,6 @@ class WC_Facebook_Product {
 			// Try to get description from post meta if fb description has been set
 			$temp_rich_text_description = get_post_meta(
 				$this->id,
-				self::FB_RICH_TEXT_DESCRIPTION,
 				self::FB_RICH_TEXT_DESCRIPTION,
 				true
 			);
@@ -764,6 +767,7 @@ class WC_Facebook_Product {
 				array(
 					'title'                 => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
 					'description'           => $this->get_fb_description(),
+					'rich_text_description' => $rich_text_description,
 					'image_link'            => $image_urls[0],
 					'additional_image_link' => $this->get_additional_image_urls( $image_urls ),
 					'link'                  => $product_url,
@@ -774,7 +778,7 @@ class WC_Facebook_Product {
 					'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 				),
-				self::$rich_text_description_source === WC_Facebookcommerce_Utils::WC_DESCRIPTION ? array( 'rich_text_description' => $rich_text_description ) : array()
+				// self::$rich_text_description_source === WC_Facebookcommerce_Utils::WC_DESCRIPTION ? array( 'rich_text_description' => $rich_text_description ) : array()
 			);
 			$product_data   = $this->add_sale_price( $product_data, true );
 			$gpc_field_name = 'google_product_category';
@@ -789,6 +793,7 @@ class WC_Facebook_Product {
 					'image_url'             => $image_urls[0],
 					'additional_image_urls' => $this->get_additional_image_urls( $image_urls ),
 					'url'                   => $product_url,
+					'rich_text_description' => $rich_text_description,
 					/**
 					 * 'category' is a required field for creating a ProductItem object when posting to /{product_catalog_id}/products.
 					 * This field should have the Google product category for the item. Google product category is not a required field
@@ -808,7 +813,7 @@ class WC_Facebook_Product {
 					'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 					'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 				),
-				self::$rich_text_description_source === WC_Facebookcommerce_Utils::WC_DESCRIPTION ? array( 'rich_text_description' => $rich_text_description ) : array()
+				// self::$rich_text_description_source === WC_Facebookcommerce_Utils::WC_DESCRIPTION ? array( 'rich_text_description' => $rich_text_description ) : array()
 			);
 
 			if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && ! empty( $video_urls ) ) {

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -34,6 +34,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		const FB_VARIANT_PATTERN = 'pattern';
 		const FB_VARIANT_GENDER  = 'gender';
 
+		const FB_DESCRIPTION = 'fb_description';
+		const WOO_DESCRIPTION = 'woo_description';
+
 		public static $ems        = null;
 		public static $store_name = null;
 
@@ -252,14 +255,14 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		 * Clean up strings for FB Graph POSTing.
 		 * This function should will:
 		 * 1. Replace newlines chars/nbsp with a real space
-		 * 2. strip_tags()
+		 * 2. strip_tags() if not explicitly stated to not
 		 * 3. trim()
 		 *
 		 * @access public
 		 * @param String string
 		 * @return string
 		 */
-		public static function clean_string( $string ) {
+		public static function clean_string( $string, $strip_html_tags = true ) {
 
 			/**
 			 * Filters whether the shortcodes should be applied for a string when syncing a product or be stripped out.
@@ -269,6 +272,10 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 			 * @param bool   $apply_shortcodes Shortcodes are applied if set to `true` and stripped out if set to `false`.
 			 * @param string $string           String to clean up.
 			 */
+
+			 if (!$string){
+				return '';
+			 }
 			$apply_shortcodes = apply_filters( 'wc_facebook_string_apply_shortcodes', false, $string );
 			if ( $apply_shortcodes ) {
 				// Apply active shortcodes
@@ -280,7 +287,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 
 			$string = str_replace( array( '&amp%3B', '&amp;' ), '&', $string );
 			$string = str_replace( array( "\r", '&nbsp;', "\t" ), ' ', $string );
-			$string = wp_strip_all_tags( $string, false ); // true == remove line breaks
+			if ($strip_html_tags){
+				$string = wp_strip_all_tags( $string, false ); // true == remove line breaks
+			}
 			return $string;
 		}
 

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -35,7 +35,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		const FB_VARIANT_GENDER  = 'gender';
 
 		const FB_DESCRIPTION = 'fb_description';
-		const WOO_DESCRIPTION = 'woo_description';
+		const WC_DESCRIPTION = 'wc_description';
 
 		public static $ems        = null;
 		public static $store_name = null;
@@ -273,7 +273,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 			 * @param string $string           String to clean up.
 			 */
 
-			 if (!$string){
+			 if (empty($string)){
 				return '';
 			 }
 			$apply_shortcodes = apply_filters( 'wc_facebook_string_apply_shortcodes', false, $string );

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -495,7 +495,6 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 
 		$_POST[ WC_Facebook_Product::FB_REMOVE_FROM_SYNC ] = $product_to_delete->get_id();
 
-		$_POST[ WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION ] = 'Facebook product description.';
 		$_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ]                   = '199';
 		$_POST['fb_product_image_source']                                 = 'Image source meta key value.';
 		$_POST[ WC_Facebook_Product::FB_PRODUCT_IMAGE ]                   = 'Facebook product image.';
@@ -524,7 +523,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 		$facebook_product_data                               = $facebook_product->prepare_product(null, \WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH );
 		$this->integration->product_catalog_id               = '123123123123123123';
 		/* Data coming from _POST data. */
-		$facebook_product_data['description']                = 'Facebook product description.';
+		$facebook_product_data['description']                = 'Dummy Product';
 		$facebook_product_data['price']                      = '199 USD';
 		$facebook_product_data['google_product_category']    = 1718;
 
@@ -555,7 +554,6 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 
 		$facebook_product_to_update = new WC_Facebook_Product( $product_to_update->get_id() );
 
-		$this->assertEquals( 'Facebook product description.', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_DESCRIPTION, true ) );
 		$this->assertEquals( '199', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_PRICE, true ) );
 		$this->assertEquals( 'http://example.orgFacebook product image.', get_post_meta( $facebook_product_to_update->get_id(), WC_Facebook_Product::FB_PRODUCT_IMAGE, true ) );
 	}
@@ -1860,7 +1858,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 		set_current_screen( 'edit-post' );
 
 		/** @var WC_Product_Simple $product */
-		$product = WC_Helper_Product::create_simple_product();
+		$product =   WC_Helper_Product::create_simple_product();
 		$product->add_meta_data( WC_Facebookcommerce_Integration::FB_PRODUCT_GROUP_ID, 'facebook-product-group-id-1' );
 		$product->add_meta_data( WC_Facebookcommerce_Integration::FB_PRODUCT_ITEM_ID, 'facebook-product-item-id-1' );
 		$product->add_meta_data( Products::VISIBILITY_META_KEY, true );

--- a/tests/Unit/fbUtilsTest.php
+++ b/tests/Unit/fbUtilsTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+
+class fbUtilsTest extends WP_UnitTestCase {
+    public function testRemoveHtmlTags() {
+        $string = '<p>Hello World!</p>';
+        $expectedOutput = 'Hello World!';
+        $actualOutput = WC_Facebookcommerce_Utils::clean_string($string, true);
+        $this->assertEquals($expectedOutput, $actualOutput);
+    } 
+
+    public function testKeepHtmlTags() {
+        $string = '<p>Hello World!</p>';
+        $expectedOutput = '<p>Hello World!</p>';
+        $actualOutput = WC_Facebookcommerce_Utils::clean_string($string, false);
+        $this->assertEquals($expectedOutput, $actualOutput);
+    }
+
+    public function testReplaceSpecialCharacters() {
+        $string = 'Hello &amp; World!';
+        $expectedOutput = 'Hello & World!';
+        $actualOutput = WC_Facebookcommerce_Utils::clean_string($string, true);
+        $this->assertEquals($expectedOutput, $actualOutput);
+    }
+
+    public function testEmptyString() {
+        $string = '';
+        $expectedOutput = '';
+        $actualOutput = WC_Facebookcommerce_Utils::clean_string($string, true);
+        $this->assertEquals($expectedOutput, $actualOutput);
+    }
+
+    public function testNullString() {
+        $string = null;
+        $expectedOutput = null;
+        $actualOutput = WC_Facebookcommerce_Utils::clean_string($string, true);
+        $this->assertEquals($expectedOutput, $actualOutput);
+    }
+}

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -377,34 +377,6 @@ class fbproductTest extends WP_UnitTestCase {
 	}	
 	
 	/**
-	 * Test html tags preservation for rich text description
-	 * @return void
-	 */
-	public function test_html_preservation_for_rich_text_description() {
-    // Create a simple product
-    $product = WC_Helper_Product::create_simple_product();
-
-    // Create a Facebook product instance
-    $facebookProduct = new \WC_Facebook_Product($product);
-
-    // Set the rich text description with HTML content
-    $htmlContent = '<html>
-        <p>Unisex cotton T-shirt with 3/4 length sleeves in royal blue. Great for everyday casual wear. Features graphic print of logo in white on upper left sleeve.</p>
-        <ul>
-            <li>100% Cotton</li>
-            <li>Relaxed Fit</li>
-        </ul>
-    </html>';
-    $facebookProduct->set_rich_text_description($htmlContent);
-
-    // Get the rich text description
-    $richTextDescription = $facebookProduct->get_rich_text_description();
-
-    // Assert that the HTML content is preserved
-    $this->assertEquals($htmlContent, $richTextDescription);
-	}
-
-	/**
 	 * Tests for get_rich_text_description() method
 	 */
 	public function test_get_rich_text_description() {

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -103,4 +103,48 @@ class fbproductTest extends WP_UnitTestCase {
 		$this->assertEquals( $description, 'fb description' );
 
 	}
+
+		
+	/**
+	 * Test it gets rich text description from post meta.
+	 * @return void
+	 */
+	public function test_get_rich_text_description_from_post_meta() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$facebook_product = new \WC_Facebook_Product( $product );
+		$facebook_product->set_rich_text_description( 'rich text description' );
+		$rich_text_description = $facebook_product->get_rich_text_description();
+
+		$this->assertEquals( $rich_text_description,  'rich text description' );
+	}	
+	
+	/**
+	 * Test html tags preservation for rich text description
+	 * @return void
+	 */
+	public function test_html_preservation_for_rich_text_description() {
+    // Create a simple product
+    $product = WC_Helper_Product::create_simple_product();
+
+    // Create a Facebook product instance
+    $facebookProduct = new \WC_Facebook_Product($product);
+
+    // Set the rich text description with HTML content
+    $htmlContent = '<html>
+        <p>Unisex cotton T-shirt with 3/4 length sleeves in royal blue. Great for everyday casual wear. Features graphic print of logo in white on upper left sleeve.</p>
+        <ul>
+            <li>100% Cotton</li>
+            <li>Relaxed Fit</li>
+        </ul>
+    </html>';
+    $facebookProduct->set_rich_text_description($htmlContent);
+
+    // Get the rich text description
+    $richTextDescription = $facebookProduct->get_rich_text_description();
+
+    // Assert that the HTML content is preserved
+    $this->assertEquals($htmlContent, $richTextDescription);
+	}
+
 }

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -147,4 +147,172 @@ class fbproductTest extends WP_UnitTestCase {
     $this->assertEquals($htmlContent, $richTextDescription);
 	}
 
+	/**
+	 * Tests for get_rich_text_description() method
+	 */
+	public function test_get_rich_text_description() {
+		// Test 1: Gets rich text description from fb_description if set
+		$product = WC_Helper_Product::create_simple_product();
+		$facebook_product = new \WC_Facebook_Product($product);
+		$facebook_product->set_description('fb description test');
+		
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('fb description test', $description);
+
+		// Test 2: Gets rich text description from rich_text_description if set
+		$facebook_product->set_rich_text_description('<p>rich text description test</p>');
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>rich text description test</p>', $description);
+
+		// Test 3: Gets rich text description from post meta
+		update_post_meta($product->get_id(), \WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION, '<p>meta description test</p>');
+		$new_facebook_product = new \WC_Facebook_Product($product); // Create new instance to clear cached values
+		$description = $new_facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>meta description test</p>', $description);
+
+		// Test 4: For variations, gets description from variation first
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$variation = wc_get_product($variable_product->get_children()[0]);
+		$variation->set_description('<p>variation description</p>');
+		$variation->save();
+		
+		$parent_fb_product = new \WC_Facebook_Product($variable_product);
+		$facebook_product = new \WC_Facebook_Product($variation, $parent_fb_product);
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>variation description</p>', $description);
+
+		// Test 5: Falls back to post content if no other description is set
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_description('<p>product content description</p>');
+		$product->save();
+		
+		$facebook_product = new \WC_Facebook_Product($product);
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>product content description</p>', $description);
+
+		// Test 6: Falls back to post excerpt if content is empty and sync_short_description is true
+		add_option(
+			WC_Facebookcommerce_Integration::SETTING_PRODUCT_DESCRIPTION_MODE,
+			WC_Facebookcommerce_Integration::PRODUCT_DESCRIPTION_MODE_SHORT
+		);
+		
+		$product->set_description('');
+		$product->set_short_description('<p>short description test</p>');
+		$product->save();
+		
+		$facebook_product = new \WC_Facebook_Product($product);
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>short description test</p>', $description);
+
+		// Test 7: Applies filters
+		add_filter('facebook_for_woocommerce_fb_rich_text_description', function($description) {
+			return '<p>filtered description</p>';
+		});
+		
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>filtered description</p>', $description);
+		
+		// Cleanup
+		remove_all_filters('facebook_for_woocommerce_fb_rich_text_description');
+		delete_option(WC_Facebookcommerce_Integration::SETTING_PRODUCT_DESCRIPTION_MODE);
+	}
+
+	/**
+	 * Test HTML preservation in rich text description
+	 */
+	public function test_rich_text_description_html_preservation() {
+		$product = WC_Helper_Product::create_simple_product();
+		$facebook_product = new \WC_Facebook_Product($product);
+
+		$html_content = '
+			<div class="product-description">
+				<h2>Product Features</h2>
+				<p>This is a <strong>premium</strong> product with:</p>
+				<ul>
+					<li>Feature 1</li>
+					<li>Feature 2</li>
+				</ul>
+				<table>
+					<tr>
+						<th>Size</th>
+						<th>Color</th>
+					</tr>
+					<tr>
+						<td>Large</td>
+						<td>Blue</td>
+					</tr>
+				</table>
+			</div>
+		';
+
+		$facebook_product->set_rich_text_description($html_content);
+		$description = $facebook_product->get_rich_text_description();
+		
+		// Test HTML structure is preserved
+		$this->assertStringContainsString('<div class="product-description">', $description);
+		$this->assertStringContainsString('<h2>', $description);
+		$this->assertStringContainsString('<strong>', $description);
+		$this->assertStringContainsString('<ul>', $description);
+		$this->assertStringContainsString('<li>', $description);
+		$this->assertStringContainsString('<table>', $description);
+		$this->assertStringContainsString('<tr>', $description);
+		$this->assertStringContainsString('<th>', $description);
+		$this->assertStringContainsString('<td>', $description);
+	}
+
+	/**
+	 * Test empty rich text description fallback behavior
+	 */
+	public function test_empty_rich_text_description_fallback() {
+		$product = WC_Helper_Product::create_simple_product();
+		$facebook_product = new \WC_Facebook_Product($product);
+		
+		// Ensure rich_text_description is empty
+		$facebook_product->set_rich_text_description('');
+		
+		// Test fallback to post meta
+		update_post_meta($product->get_id(), \WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION, '<p>fallback description</p>');
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>fallback description</p>', $description);
+		
+		// Test behavior when both rich_text_description and post meta are empty
+		delete_post_meta($product->get_id(), \WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION);
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('', $description);
+	}
+
+	/**
+	 * Test rich text description handling for variable products and variations
+	 */
+	public function test_rich_text_description_variants() {
+		// Create variable product with variation
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$variation = wc_get_product($variable_product->get_children()[0]);
+		
+		// Set up parent product
+		$parent_fb_product = new \WC_Facebook_Product($variable_product);
+		
+		// Set the rich text description using post meta for the parent
+		update_post_meta($variable_product->get_id(), \WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION, '<p>parent rich text</p>');
+		
+		// Test 1: Variation inherits parent's rich text description when empty
+		$facebook_product = new \WC_Facebook_Product($variation, $parent_fb_product);
+		$description = $facebook_product->get_rich_text_description();
+		$this->assertEquals('<p>parent rich text</p>', $description);
+		
+		// Test 2: Variation uses its own rich text description when set
+		$variation_fb_product = new \WC_Facebook_Product($variation, $parent_fb_product);
+		$variation_fb_product->set_rich_text_description('<p>variation rich text</p>');
+		$description = $variation_fb_product->get_rich_text_description();
+		$this->assertEquals('<p>variation rich text</p>', $description);
+		
+		// // Test 3: Variation uses its post meta when set
+		// update_post_meta($variation->get_id(), \WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION, '<p>variation meta rich text</p>');
+		// $new_variation_product = new \WC_Facebook_Product($variation, $parent_fb_product);
+		// $description = $new_variation_product->get_rich_text_description();
+		// $this->assertEquals('<p>variation meta rich text</p>', $description);
+		
+		// Test 4: Fallback chain for variations
+		delete_post_meta($variation->get_id(), \WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION);
+	}
 }


### PR DESCRIPTION
Changes proposed in this Pull Request:

This PR introduces a new feature to the Facebook WooCommerce Plugin, allowing users to add rich text descriptions to their products. With this update, we can seamlessly synchronize the rich text description field with the Facebook Commerce Manager platform.

<img width="1244" alt="Screenshot 2024-11-04 at 11 21 23" src="https://github.com/user-attachments/assets/eb1c1fbb-5734-4c27-b710-1e031f1a58e6">
<img width="601" alt="Screenshot 2024-11-04 at 11 22 26" src="https://github.com/user-attachments/assets/a40f84e8-3127-4b62-a87d-c172ab257a98">
<img width="753" alt="Screenshot 2024-11-04 at 11 22 41" src="https://github.com/user-attachments/assets/75063389-5a78-4ae2-a73f-c2a392427472">

