### PR TITLE
T206230215: Expose Brand & MPN to Woocommerce UI

### DIFF
--- a/data/google_category_to_attribute_mapping_fields.json
+++ b/data/google_category_to_attribute_mapping_fields.json
@@ -1,1 +1,3026 @@
-{"5773e3cf8b57a590831b2fa4966071b7":{"key":"gender","fieldname":"Gender","recommended":false,"type":"enum","description":"Gender the product item is targeted towards","enum_values":["female","male","unisex"],"can_have_unknown_value":false},"48f499603e045536424c8db9e2b51338":{"key":"brand","fieldname":"Brand","recommended":false,"type":"string","description":"Brand name, unique manufacturer part number (MPN), or Global Trade Item Number (GTIN) of the item."},"e44fa2f9d73d8394fc19e11bda594270":{"key":"color","fieldname":"Color","recommended":false,"type":"string","description":"Color of the product item"},"3c93dcbe5e2427633884455f8fdf3d0a":{"key":"size","fieldname":"size","recommended":false,"type":"string","description":"Size of the product item"},"14360682ab38bda0c27cd410da1ddb93":{"key":"pattern","fieldname":"Pattern","recommended":false,"type":"string","description":"Pattern of the product item"},"57a5027e44183e4bee60fd79e0f72215":{"key":"material","fieldname":"Material","recommended":false,"type":"string","description":"Material of the product item"},"536559919dfbf7c806f82836c7b6ace0":{"key":"age_group","fieldname":"AgeGroup","recommended":false,"type":"enum","description":"Age group the product item is targeted towards","enum_values":["adult","all ages","infant","kids","newborn","teen","toddler"],"can_have_unknown_value":false},"fdbb66325f7179c53e0d013f85a8f1bb":{"key":"material","fieldname":"Material","recommended":true,"type":"string","description":"Material of the product item"},"56beea7a921d2d0a4b65bcb91de4619f":{"type":"measurement","example":"10 g","enum_values":["mg","g","kg","oz","lb"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"MinimumWeight","key":"minimum_weight","recommended":true,"description":"The lower weight limit or capability of an item,often used in conjunction with \"Maximum Weight\".The meaning varies with context of product.For example, when used with \"Maximum Weight\",this attribute provides weight ranges for a range of productsincluding pet medicine, baby carriers and outdoor play structures."},"b4e2ba079a90aafe22d7b40a27a8a86b":{"type":"string","example":"1-3 Years","can_have_multiple_values":false,"fieldname":"AgeRange","key":"age_range","recommended":true,"description":"Minimum and Maximum Ages for a product. Note: the unit of measure in\n        Months, or Years."},"d86e410dc0b595fa52c8071297df164e":{"type":"measurement","example":"10 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"ProductWidth","key":"product_width","recommended":true,"description":"The width of the fully assembled product."},"fb29eb2f1bed6b57202be5766b13a012":{"key":"color","fieldname":"Color","recommended":true,"type":"string","description":"Color of the product item"},"6f6763dc75294a1700c3325ed0e01501":{"type":"measurement","example":"10 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"ProductLength","key":"product_length","recommended":true,"description":"The length of the fully assembled product."},"a125082f8b596fd6a3fc4ef69aac4ce9":{"key":"gender","fieldname":"Gender","recommended":true,"type":"enum","description":"Gender the product item is targeted towards","enum_values":["female","male","unisex"],"can_have_unknown_value":false},"b77f4835261839838cf7da93a4397624":{"type":"measurement","example":"10 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"ProductHeight","key":"product_height","recommended":true,"description":"The height of the fully assembled product"},"fab78b5f78ea9c6822f0efd4b76812c7":{"type":"measurement","example":"10 g","enum_values":["mg","g","kg","oz","lb"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"MaximumWeight","key":"maximum_weight","recommended":true,"description":"The upper weight limit or capability of an item,often used in conjunction with \"Minimum Weight\".The meaning varies with context of product.For example, when used with \"Minimum Weight\",this attribute provides weight ranges for a range of productsincluding pet medicine, baby carriers and outdoor play structures."},"c33d8f504a0d16cc768948032b96bb86":{"type":"string","example":["Waterproof"],"can_have_multiple_values":true,"fieldname":"AdditionalFeatures","key":"additional_features","recommended":false,"description":"Additional features related to your item that might be important for buyers."},"75d33e09027a3e497cd7f4871c44d0ad":{"type":"string","example":"Shape Identification","can_have_multiple_values":false,"fieldname":"EducationalFocus","key":"educational_focus","recommended":false,"description":"Describes the educational skills that the product is intended to improve"},"a61b31aad2b1cff7a5e059435aa0c079":{"type":"string","example":"Chewbacca","can_have_multiple_values":false,"fieldname":"Character","key":"character","recommended":false,"description":"The particular character, person or entity that your item represents or is associated with."},"186773615b385aea09f78bf7846c2da2":{"type":"string","example":"Space","can_have_multiple_values":false,"fieldname":"Theme","key":"theme","recommended":false,"description":"The particular subject, theme or idea that your item represents or is associated with."},"f0cc9df58632d42a9f64e187e36822ac":{"type":"boolean","example":"yes","can_have_multiple_values":false,"can_have_unknown_value":false,"enum_values":["yes","no"],"fieldname":"IsAssemblyRequired","key":"is_assembly_required","recommended":true,"description":"Indicates if the product arrives unassembledand must be put together before use."},"18213b9375e78464379a596bc5a12105":{"type":"string","example":"jogging","can_have_multiple_values":false,"fieldname":"StrollerType","key":"stroller_type","recommended":false,"description":"Prominent stroller styles."},"e294d165c14bf93d4ff9d565c45b86f0":{"type":"enum","example":["Foldable"],"can_have_multiple_values":true,"enum_values":["Foldable"],"can_have_unknown_value":false,"fieldname":"StandardFeatures","key":"standard_features","recommended":false,"description":"Standard features related to your item that might be important for buyers."},"09e6b8670b86e122237dee1d1948f5e3":{"type":"string","example":"3-point harness","can_have_multiple_values":false,"fieldname":"SafetyHarnessStyle","key":"safety_harness_style","recommended":false,"description":"The style of the occupant restraint harness included with the car\n          seat, stroller, carrier, etc."},"5a781cf5acf5b20a3457889ab0719688":{"type":"integer","example":1,"can_have_multiple_values":false,"fieldname":"NumberOfSeats","key":"number_of_seats","recommended":false,"description":"The number of people that can be accommodated by the\n        available seats of an item."},"acb1aef05b9c5b358e8d767422053a0c":{"type":"string","example":"Convertible Car Seats","can_have_multiple_values":false,"fieldname":"ChildCarSeatStyle","key":"child_car_seat_style","recommended":false,"description":"Prominent car seat styles."},"84520363ef89687443e2b75aac0ca2a4":{"type":"string","example":"3 ft","can_have_multiple_values":false,"fieldname":"CarSeatMaxChildHeight","key":"car_seat_max_child_height","recommended":false,"description":"The maximum height of the child occupant as given by the\n          manufacturer, measured in inches or centimeters."},"9d014a512c1e3019550901b0c0494ff4":{"type":"string","example":"Forward-Facing","can_have_multiple_values":false,"fieldname":"CarSeatFacingDirection","key":"car_seat_facing_direction","recommended":false,"description":"Which direction the car seat faces."},"c139a1077e40bc1ed55105d8250cfbd7":{"type":"string","example":"sling","can_have_multiple_values":false,"fieldname":"BabyCarrierStyle","key":"baby_carrier_style","recommended":false,"description":"Prominent wearable baby carrier styles."},"de2ea24937f3cfb9d23a6184b6bb1717":{"type":"string","example":"front carry-facing in","can_have_multiple_values":false,"fieldname":"BabyCarrierPosition","key":"baby_carrier_position","recommended":false,"description":"Applies to wearable baby carriers. Describes the part of the body\n          against which the child is placed along with the direction the child\n          faces (where applicable) while in the wearable baby carrier."},"3e6c4c356607b43e111bc414a797367c":{"type":"integer","example":12,"can_have_multiple_values":false,"fieldname":"PackageQuantity","key":"package_quantity","recommended":true,"description":"The total number of items included in the package or box."},"b2e91b6002cde2bfa85933056e1fbab1":{"key":"size","fieldname":"size","recommended":true,"type":"string","description":"Size of the product item"},"e84c396def9cf6dfa460ad427e4086f1":{"type":"string","example":["Stop using if you experience swelling, rash, or fever"],"can_have_multiple_values":true,"fieldname":"StopUseIndications","key":"stop_use_indications","recommended":false,"description":"Information that describes symptoms or reactions that\n        indicate when to stop using the product."},"f9f15a8a99459328f839fb1423283f15":{"type":"string","example":["Vanilla"],"can_have_multiple_values":true,"fieldname":"Scent","key":"scent","recommended":false,"description":"The scent or fragrance of your item; including items\n        labelled as \"unscented\""},"ad4e681a4cf1c32d992b0119533bb4f3":{"type":"string","example":"Oil","can_have_multiple_values":false,"fieldname":"ProductForm","key":"product_form","recommended":false,"description":"The consistency, texture or formulation of the item and the way\n          it will be consumed or dispensed."},"4ddda60fca4317fa3a260bc6a716eacb":{"type":"measurement","example":"10 g","enum_values":["mg","g","kg","oz","lb"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"MaximumWeight","key":"maximum_weight","recommended":false,"description":"The upper weight limit or capability of an item,often used in conjunction with \"Minimum Weight\".The meaning varies with context of product.For example, when used with \"Minimum Weight\",this attribute provides weight ranges for a range of productsincluding pet medicine, baby carriers and outdoor play structures."},"9bf1fceb6bbc26681a6531a069d97089":{"type":"measurement","example":"10 g","enum_values":["mg","g","kg","oz","lb"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"MinimumWeight","key":"minimum_weight","recommended":false,"description":"The lower weight limit or capability of an item,often used in conjunction with \"Maximum Weight\".The meaning varies with context of product.For example, when used with \"Maximum Weight\",this attribute provides weight ranges for a range of productsincluding pet medicine, baby carriers and outdoor play structures."},"1b2a0250577aa3367755a9d309396596":{"type":"string","example":["Apply to wet hair","Massage into scalp","Rinse thoroughly"],"can_have_multiple_values":true,"fieldname":"Instructions","key":"instructions","recommended":false,"description":"Detailed information telling how the product should be operated,\n           assembled, or consumed."},"cb857165d244dc15e39ea8f1e8752ee8":{"type":"string","example":["some_string","other"],"can_have_multiple_values":true,"fieldname":"Ingredients","key":"ingredients","recommended":false,"description":"The list of all ingredients contained in an item, as found on the product label mandated by FDA guidelines."},"06824c1d350fd02b20f1ccb63dc70aa2":{"type":"string","example":"Cloth","can_have_multiple_values":false,"fieldname":"DiaperType","key":"diaper_type","recommended":false,"description":"Describes the type of diaper"},"fdb673fe23dcfd4e913ea68db30f1886":{"type":"enum","example":"Infant","can_have_multiple_values":false,"enum_values":["Newborn","Infant","Toddler"],"can_have_unknown_value":false,"fieldname":"BabyLifeStage","key":"baby_life_stage","recommended":false,"description":"Describes the life stage of the child"},"4a1709fc558601d050f61caacf1886f7":{"type":"string","example":"Stage 1","can_have_multiple_values":false,"fieldname":"BabyFoodStage","key":"baby_food_stage","recommended":true,"description":"Attribute designed to capture the generalized age grouping (commonly referred to as \"stage\") of a given baby food, as specified by manufacturer. Example descriptions: Stage 1 -  Foods have a single ingredient and are pureed and generally contain about 2.5 oz  of fruits, veggies or meats. Stage 2  -  Foods are strained instead of pureed and have a combination of fruits or veggies instead of single ingredients, contain larger portions. Stage 3  -  Foods are mashed and have more texture than the pureed foods and may have bits and chunks of meats or veggies."},"b5ab18b31d909d41c1dc88e00bac6e44":{"type":"measurement","example":"10 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"ProductWidth","key":"product_width","recommended":false,"description":"The width of the fully assembled product."},"812cdd6be6bd77d8fae155eee4b5ca8e":{"type":"measurement","example":"10 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"ProductLength","key":"product_length","recommended":false,"description":"The length of the fully assembled product."},"045b717bb79c0b39f9d17afd53120c44":{"type":"measurement","example":"10 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"ProductHeight","key":"product_height","recommended":false,"description":"The height of the fully assembled product"},"666634cdd39d094fdf806ea000651fd9":{"type":"integer","example":12,"can_have_multiple_values":false,"fieldname":"PackageQuantity","key":"package_quantity","recommended":false,"description":"The total number of items included in the package or box."},"1f60a7e1c843194aef22644bdc923372":{"type":"string","example":["Yams"],"can_have_multiple_values":true,"fieldname":"Ingredients","key":"ingredients","recommended":false,"description":"The list of all ingredients contained in an item, as found on the product label mandated by FDA guidelines."},"0412c658ae5558750f3d8dcf73b35e2f":{"type":"string","example":["Cinnamon","Peppermint"],"can_have_multiple_values":true,"fieldname":"Flavor","key":"flavor","recommended":false,"description":"Describes the taste or flavor of the item, as described by the\n          manufacturer. May be an important attribute for shoppers for items\n          like dental products, medicine or baby foods."},"003aaedcb75e3bdf52a4a7c043bc83bf":{"type":"string","example":"Contains Peanuts","can_have_multiple_values":false,"fieldname":"Allergens","key":"allergens","recommended":false,"description":"Statement regarding any ingredients that may be food allergens, often written as \"Contains X\" or \"Manufactured in a facility which processes Y.\""},"f29ece641eb9d606c99f8ff1375cdafd":{"type":"string","example":16,"can_have_multiple_values":false,"fieldname":"Megapixels","key":"megapixels","recommended":true,"description":"Describes the resolution at which this item records images."},"198abe5c383734cf1f5c25725ad05626":{"type":"string","example":6,"can_have_multiple_values":false,"fieldname":"DigitalZoom","key":"digital_zoom","recommended":true,"description":"Describes the magnification power provided by a feature that electronically enlarges the image area"},"3c84275e3f255e24439d4d2acca1738c":{"type":"string","example":10,"can_have_multiple_values":false,"fieldname":"OpticalZoom","key":"optical_zoom","recommended":true,"description":"Describes the magnification power of a physical optical zoom lens."},"5546fa0a68017a13c3d54f434b16e543":{"type":"string","example":"Lenovo Thinkpad","can_have_multiple_values":false,"fieldname":"Model","key":"model","recommended":true,"description":"The common name of the model of the product. Does not include model numbers."},"c4140fbb308019e33a32ebef93a21145":{"key":"brand","fieldname":"Brand","recommended":true,"type":"string","description":"Brand name, unique manufacturer part number (MPN), or Global Trade Item Number (GTIN) of the item."},"c73360481bac2974a2647239ba9ac090":{"type":"string","example":"USB 2.0","can_have_multiple_values":false,"fieldname":"USBTechnology","key":"u_s_b_technology","recommended":false,"description":"Describes the version of USB technology on the product."},"fb5d85a3717fff61798f843282121fc6":{"type":"enum","example":["Flash"],"can_have_multiple_values":true,"enum_values":["35mm Jack","Downloadable Content","Online Multiplayer","Touchscreen","Bluetooth","GPS","SIM","USB Connectivity","WLAN","Portable","Unlocked","Auto Document Feeder","Auto Two-Sided Printing","Energy Star Certified","Integrated Speakers","3D","Smart","Flash","Microphone","Red Eye Reduction"],"can_have_unknown_value":false,"fieldname":"StandardFeatures","key":"standard_features","recommended":false,"description":"Standard features related to your item that might be important for buyers."},"e52c7222866dfa79fb54fb46377f2dba":{"type":"string","example":"USB-C","can_have_multiple_values":false,"fieldname":"USBType","key":"u_s_b_type","recommended":false,"description":"Describes the type of USB connector on the product."},"a557ee533a27f6ba2ab2896f50128d2b":{"type":"string","example":["Portrait"],"can_have_multiple_values":true,"fieldname":"ShootingModes","key":"shooting_modes","recommended":false,"description":"Describes the available settings designed to accommodate different photographic situations."},"cb76a2503550b23c7e96374acff9974c":{"type":"string","example":250,"can_have_multiple_values":false,"fieldname":"MinimumShutterSpeed","key":"minimum_shutter_speed","recommended":false,"description":"Describes the minimum shutter speed of the item. Measured in seconds."},"dfa8888400db20a0c59123675195f680":{"type":"string","example":2,"can_have_multiple_values":false,"fieldname":"SelfTimerDelay","key":"self_timer_delay","recommended":false,"description":"Length of time in seconds the self-timer will allow before it\n          takes a photo"},"80a2c75641a182aabe897e4d0c5c8ea2":{"type":"measurement","example":"42 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"ScreenSize","key":"screen_size","recommended":false,"description":"Describes the measurement of the device's screen, typically measured diagonally in inches."},"4b71478ae3751b69220f8f35f0f65ab9":{"type":"string","example":"1\/2.3 in","can_have_multiple_values":false,"fieldname":"SensorResolution","key":"sensor_resolution","recommended":false,"description":"One specification describing the smallest detectable incremental change of input parameter that can be detected in the output signal. For digital cameras, image sensor resolution is an important factor for image quality."},"82aef4349fbc23a369243c604b574e3a":{"type":"string","example":"f\/16","can_have_multiple_values":false,"fieldname":"MinimumAperture","key":"minimum_aperture","recommended":false,"description":"The smallest aperture this item accommodates; typically expressed in f-numbers."},"73d65ceca095eeba210477fa2c3566ca":{"type":"string","example":"f\/5","can_have_multiple_values":false,"fieldname":"FocalRatio","key":"focal_ratio","recommended":false,"description":"Ratio of the lens's focal length, to the diameter of the entrance pupil. Also known as the f-number or f-stop, this number indicates lens speed."},"7518e31e367a461a82c93d537dc2c7da":{"type":"string","example":["iPad"],"can_have_multiple_values":true,"fieldname":"CompatibleDevices","key":"compatible_devices","recommended":false,"description":"Devices compatible with the item."},"ba6bb30e5d011b3182c2d01d3ec52356":{"type":"string","example":"HDMI","can_have_multiple_values":false,"fieldname":"ConnectorType","key":"connector_type","recommended":false,"description":"Describes the types of connections supported on the item."},"aaa86538e1892f9637b83693ea86da06":{"type":"string","example":"LCD","can_have_multiple_values":false,"fieldname":"DisplayTechnology","key":"display_technology","recommended":false,"description":"Describes the type of technology that powers the display, like LED or LCD."},"3f3305be9612e01d2d0b854c2e23dd0f":{"type":"string","example":"Built-in Camera","can_have_multiple_values":false,"fieldname":"FlashType","key":"flash_type","recommended":false,"description":"The type of flash the camera has or can accommodate."},"27ac044687275eca92c8ffc695dfcfac":{"type":"string","example":18,"can_have_multiple_values":false,"fieldname":"FocalLength","key":"focal_length","recommended":false,"description":"On a camera or lens, the distance between the image sensor and the lens when the subject is in focus,stated as a range in millimeters."},"b5dd74005f37c4313d88aaf9ec09a6ce":{"type":"measurement","example":"10 h","enum_values":["s","m","h","d"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"BatteryLife","key":"battery_life","recommended":false,"description":"Describes the total battery life (or maximum run time) of the item, typically measured in hours."},"25dd344c790ce67c74887cef8bf51bf9":{"type":"string","example":["Scratch-Resistant"],"can_have_multiple_values":true,"fieldname":"LensCoating","key":"lens_coating","recommended":false,"description":"Type of thin layer of material applied to the surface of lenses or other optical elements that provide specific effects."},"37ced536fc643daf19b3e78c6109d462":{"type":"string","example":49,"can_have_multiple_values":false,"fieldname":"LensDiameter","key":"lens_diameter","recommended":false,"description":"Measurement of the diameter of the front portion of the lens, measured in mm."},"fa1806a7580ccac912c41dc13a38f9f2":{"type":"string","example":"Cooling","can_have_multiple_values":false,"fieldname":"LensFilter","key":"lens_filter","recommended":false,"description":"Describes the kind of filter attached to a lens."},"ee8a6aaa75b14a3f55320e0ff3bf4e19":{"type":"string","example":"f\/1.4","can_have_multiple_values":false,"fieldname":"MaximumAperture","key":"maximum_aperture","recommended":false,"description":"Size of the largest aperture this item accommodates; typically expressed in f-numbers."},"2693162e8e03185c2f7147c2ed198794":{"type":"string","example":0.00025,"can_have_multiple_values":false,"fieldname":"MaximumShutterSpeed","key":"maximum_shutter_speed","recommended":false,"description":"Describes the maximum shutter speed of the item. Measured in seconds."},"2af16c00b68ea710c43881873f0c0eab":{"type":"string","example":["WiFi"],"can_have_multiple_values":true,"fieldname":"WirelessTechnologies","key":"wireless_technologies","recommended":false,"description":"Describes the types of wireless technologies that can be used by the product."},"1d70a2d3ce76a127d1ffb1b2f4209ac9":{"key":"age_group","fieldname":"AgeGroup","recommended":true,"type":"enum","description":"Age group the product item is targeted towards","enum_values":["adult","all ages","infant","kids","newborn","teen","toddler"],"can_have_unknown_value":false},"6d21b5b1295293a171d1c7d989e9db81":{"type":"string","example":["Bodycon"],"can_have_multiple_values":true,"fieldname":"Style","key":"style","recommended":true,"description":"The style(s) associated with the item."},"df971d2b5138c017068b1b1ca5fe7ff0":{"key":"pattern","fieldname":"Pattern","recommended":true,"type":"string","description":"Pattern of the product item"},"7992ac8898667c0ac4a874e914c71ec0":{"type":"string","example":["Designer","Embroidered"],"can_have_multiple_values":true,"fieldname":"AdditionalFeatures","key":"additional_features","recommended":false,"description":"Additional features related to your item that might be important for buyers."},"03321e77f42ca941c319d9d3a696e822":{"type":"string","example":"Flutter","can_have_multiple_values":false,"fieldname":"SleeveStyle","key":"sleeve_style","recommended":false,"description":"The style of sleeves. Does not include sleeve length styles."},"ef7cf809c0d3f3dde722b692949e8a82":{"type":"enum","example":"US","can_have_multiple_values":false,"enum_values":["US","UK","EU","DE","FR","JP","CN","IT","BR","MEX","AU"],"can_have_unknown_value":true,"fieldname":"SizeSystem","key":"size_system","recommended":false,"description":"The size system used by your item, usually corresponds to Country."},"891fd9d63794da9979642269ffdf2bdb":{"type":"measurement","example":"32 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"SkirtLength","key":"skirt_length","recommended":false,"description":"The numeric length value of shirt sleeves. Does not include styles of shirt sleeves like 3\/4 Sleeve."},"d0074b6e5f6d004d8b24dee11da5c838":{"type":"measurement","example":"32 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"SleeveLength","key":"sleeve_length","recommended":false,"description":"The numeric length value of skirts from waist to bottom. Does not include style values like Maxi."},"c49d53b2f6e3b840d1b3b36cf763b823":{"type":"enum","example":"3\/4 Sleeve","can_have_multiple_values":false,"enum_values":["3\/4 Sleeve","Long Sleeve","Short Sleeve","Sleeveless"],"can_have_unknown_value":true,"fieldname":"SleeveLengthStyle","key":"sleeve_length_style","recommended":false,"description":"The style of sleeve length. Does not include sleeve styles."},"ebc88b022a77d94e80822b572e926b7a":{"type":"string","example":["Tennis"],"can_have_multiple_values":true,"fieldname":"Sport","key":"sport","recommended":false,"description":"The particular sport or activity for which your item is intended."},"5db117ce3ae7225ccccb737276630902":{"type":"enum","example":"Ankle","can_have_multiple_values":false,"enum_values":["Ankle","Crew","Knee High","Mid Calf","No Show","Over the Knee","Thigh High"],"can_have_unknown_value":true,"fieldname":"SockRise","key":"sock_rise","recommended":false,"description":"The height style of socks."},"bde7f38a6a5fa76697d288227050040e":{"type":"string","example":["Golden State Warriors"],"can_have_multiple_values":true,"fieldname":"SportsLeague","key":"sports_league","recommended":false,"description":"The particular sports league that your item represents or is associated with."},"f87289e65273a3a8c33c2fd3dc5b6d4b":{"type":"string","example":["NFL"],"can_have_multiple_values":true,"fieldname":"SportsTeam","key":"sports_team","recommended":false,"description":"The particular sports team that your item represents or is associated with."},"a9dc83480290657ae724a1d0fe346563":{"type":"enum","example":["Water Resistant"],"can_have_multiple_values":true,"enum_values":["Waterproof","Water Resistant"],"can_have_unknown_value":false,"fieldname":"StandardFeatures","key":"standard_features","recommended":false,"description":"Standard features related to your item that might be important for buyers."},"790ed72ed6a00633b47d5959d9869e00":{"type":"string","example":"Racerback","can_have_multiple_values":false,"fieldname":"UpperBodyStrapConfiguration","key":"upper_body_strap_configuration","recommended":false,"description":"The strap style for items like tops, bras, and swimsuits."},"8b9b340f74a391da8163b1edfbaeeef9":{"type":"string","example":"Ultra High","can_have_multiple_values":false,"fieldname":"WaistRise","key":"waist_rise","recommended":false,"description":"The height where the waistline of the item lies on the body."},"ed9805103a40909dbd170d6a15d59e57":{"type":"measurement","example":"30 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"WaistSize","key":"waist_size","recommended":false,"description":"The numeric size of the waist for lower body garments. Does not include generic sizes like Small."},"59d583067536c9a9f0092ad4349b4107":{"type":"string","example":"Opaque","can_have_multiple_values":false,"fieldname":"Sheerness","key":"sheerness","recommended":false,"description":"The amount of sheerness or opacity of an item. Usually used for hosiery items."},"5917325df899badf730967031c51828e":{"type":"string","example":"Relaxed","can_have_multiple_values":false,"fieldname":"PantFit","key":"pant_fit","recommended":false,"description":"The general fit style of pants. Also applies to jeans."},"5d2faf8e7cd918c37585a3582ce67d41":{"type":"string","example":"Ankle","can_have_multiple_values":false,"fieldname":"PantLengthStyle","key":"pant_length_style","recommended":false,"description":"The length style of pants. Also applies to jeans & leggings."},"79d33c7a4244cde541284dffebd8af57":{"type":"string","example":["Distressed","Faded"],"can_have_multiple_values":true,"fieldname":"DenimFeatures","key":"denim_features","recommended":false,"description":"Features, embellishments & finishes that are specific to jeans."},"088788414687d075b58111bf0a9e6b28":{"type":"integer","example":32,"can_have_multiple_values":false,"fieldname":"BraBandSize","key":"bra_band_size","recommended":false,"description":"The band size of the bra."},"f8cd81278f0a424f4552e69119f8ce3e":{"type":"string","example":"A","can_have_multiple_values":false,"fieldname":"BraCupSize","key":"bra_cup_size","recommended":false,"description":"The cup size of the bra."},"3eb05a953435b526264c76134a8b02df":{"type":"measurement","example":"34 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"ChestSize","key":"chest_size","recommended":false,"description":"The numeric size of the chest measurement for the item. Does not include generic sizes like Small."},"7951a620026294a95a0ac44f9ba71eee":{"type":"string","example":"Zipper","can_have_multiple_values":false,"fieldname":"Closure","key":"closure","recommended":false,"description":"The type of fastener used to close your item."},"114da48906462d334d5d7f59893d434d":{"type":"enum","example":"Big & Tall","can_have_multiple_values":false,"enum_values":["Big & Tall","Regular","Big Boys","Big Girls","Full Size","Little Boys","Little Girls","Petite","Plus","Maternity","Baby Boy","Baby Girls","Toddler Boys","Toddler Girls"],"can_have_unknown_value":true,"fieldname":"ClothingSizeType","key":"clothing_size_type","recommended":false,"description":"The general grouping of different sizes based on age & gender."},"e1cc3ced186fc459db4f1778dabbc6c0":{"type":"string","example":"Banded","can_have_multiple_values":false,"fieldname":"CollarStyle","key":"collar_style","recommended":false,"description":"The style of collar on your item."},"07a68126da1326bbb99e0ffd81455258":{"type":"string","example":["Do Not Iron","Dry Clean Only"],"can_have_multiple_values":true,"fieldname":"FabricCareInstructions","key":"fabric_care_instructions","recommended":false,"description":"The specific care instructions for how the fabric of your item should be cleaned. This can be found on the label of the item."},"c4398a3afbb4b58166ab7090026a1c5f":{"type":"string","example":"Boot Cut","can_have_multiple_values":false,"fieldname":"PantLegStyle","key":"pant_leg_style","recommended":false,"description":"The style or cut of pant legs. Also applies to jeans."},"8908691dbe1fc7cf9b8ec543a30ccf74":{"type":"measurement","example":"30 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"Inseam","key":"inseam","recommended":false,"description":"The numeric size of the inseam for items like pants, jeans and leggings. Does not include generic sizes like Small."},"0c682655422cf862d012da48c74e9045":{"type":"boolean","example":"yes","can_have_multiple_values":false,"can_have_unknown_value":false,"enum_values":["yes","no"],"fieldname":"IsAdultProduct","key":"is_adult_product","recommended":false,"description":"Indicates if your product is sexually suggestive and intended only for adults."},"e32d81cb2795fb799d41e9beb75914a1":{"type":"boolean","example":"yes","can_have_multiple_values":false,"can_have_unknown_value":false,"enum_values":["yes","no"],"fieldname":"IsCostume","key":"is_costume","recommended":false,"description":"Indicates if the item is intended to be worn as a costume."},"044e1e8f4a2fb735e0f63e44c3217379":{"type":"boolean","example":"yes","can_have_multiple_values":false,"can_have_unknown_value":false,"enum_values":["yes","no"],"fieldname":"IsOutfitSet","key":"is_outfit_set","recommended":false,"description":"Indicates if the product has 2 or more different items that come as part of a matching or oufit set, like matching shirt & pants or bra & underwear set"},"11c967a5fc1a473d71ba4e8ac43d35c4":{"type":"string","example":"Acid Wash","can_have_multiple_values":false,"fieldname":"JeanWash","key":"jean_wash","recommended":false,"description":"The post-process wash treatment that may alter color or texture of denim products."},"f26b323c65bc8413143b53c424cb106c":{"type":"string","example":"Crew Neck","can_have_multiple_values":false,"fieldname":"Neckline","key":"neckline","recommended":false,"description":"The neckline or neck style of the item."},"efe63cfc2af39e9b3904b04f339137a8":{"type":"string","example":["Bridesmaid"],"can_have_multiple_values":true,"fieldname":"Occasion","key":"occasion","recommended":false,"description":"The type of special occassion(s) for which your item is intended or specialized."},"00efcecb28226b61fa715ceed2408546":{"type":"string","example":"Banded","can_have_multiple_values":false,"fieldname":"WaistStyle","key":"waist_style","recommended":false,"description":"The style of the waist on the item. Can apply to pants or dresses."},"f8b8550acb981fe24299736073b56104":{"type":"string","example":["Bow Tie"],"can_have_multiple_values":true,"fieldname":"Style","key":"style","recommended":true,"description":"The style(s) associated with the item."},"a53318a479999a52de362427c1af31da":{"type":"string","example":"Narrow","can_have_multiple_values":false,"fieldname":"SunglassesWidth","key":"sunglasses_width","recommended":false,"description":"The width of the sunglasses frame."},"422e14c47d8c95351a13574b5ffe3076":{"type":"string","example":"Anti-Reflective","can_have_multiple_values":false,"fieldname":"SunglassesLensTechnology","key":"sunglasses_lens_technology","recommended":false,"description":"The technology or treatment of sunglasses lenses."},"36415ae546c8d7681c9ede23fdc1ddc3":{"type":"enum","example":"Beige","can_have_multiple_values":false,"enum_values":["Beige","Black","Blue","Bronze","Brown","Gold","Gray","Green","Multi-Color","Orange","Pink","Purple","Red","Silver","White","Yellow"],"can_have_unknown_value":true,"fieldname":"SunglassesLensColor","key":"sunglasses_lens_color","recommended":false,"description":"The color of sunglasses lenses."},"70c39caa59cfd987167f972dd9aba990":{"type":"string","example":"Classic","can_have_multiple_values":false,"fieldname":"TieWidth","key":"tie_width","recommended":false,"description":"The width of tie."},"8125fc680ed8690436264f94a52dd4e9":{"type":"string","example":["Chukka"],"can_have_multiple_values":true,"fieldname":"Style","key":"style","recommended":true,"description":"The style(s) associated with the item."},"cd9f78020f15de834fcc58d3d563ebac":{"type":"string","example":"A","can_have_multiple_values":false,"fieldname":"ShoeWidth","key":"shoe_width","recommended":true,"description":"The width of the shoes."},"b0bd5a2777af18be80307b03175a050a":{"type":"enum","example":["Water Resistant"],"can_have_multiple_values":true,"enum_values":["Orthopedic","Waterproof","Water Resistant"],"can_have_unknown_value":false,"fieldname":"StandardFeatures","key":"standard_features","recommended":false,"description":"Standard features related to your item that might be important for buyers."},"30bc46e76de465db006632f51b9dc9bc":{"type":"enum","example":"Flats","can_have_multiple_values":false,"enum_values":["Flats","Boots","Heels","Sandals","Slippers","Athletic Shoes","Fashion Sneakers"],"can_have_unknown_value":true,"fieldname":"ShoeType","key":"shoe_type","recommended":false,"description":"The type of shoes."},"eb7731477ae172c98b8653d26038d351":{"type":"string","example":"Wedge","can_have_multiple_values":false,"fieldname":"HeelStyle","key":"heel_style","recommended":false,"description":"The style of heel on the shoes."},"9847453e3dfb3f97dd262911e96927fc":{"type":"measurement","example":"0.5 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"HeelHeight","key":"heel_height","recommended":false,"description":"The numeric height of the heel on the shoes."},"24cdfc97c883070990bfe53a9ab4fcc1":{"type":"string","example":["Hoops"],"can_have_multiple_values":true,"fieldname":"Style","key":"style","recommended":true,"description":"The style(s) associated with the item."},"ae3548dbfd62e601abeefe809b9804fe":{"type":"string","example":["Ruby","Emerald"],"can_have_multiple_values":true,"fieldname":"Gemstone","key":"gemstone","recommended":true,"description":"The type of gemstone(s) in your item."},"c2b8ee902fdca1b35815f183af905f6a":{"type":"string","example":["Vintage","Engraved"],"can_have_multiple_values":true,"fieldname":"AdditionalFeatures","key":"additional_features","recommended":false,"description":"Additional features related to your item that might be important for buyers."},"f0933d6a49ace1948a6f904be052d459":{"type":"enum","example":["Resizable"],"can_have_multiple_values":true,"enum_values":["Resizable","Water Resistant"],"can_have_unknown_value":false,"fieldname":"StandardFeatures","key":"standard_features","recommended":false,"description":"Standard features related to your item that might be important for buyers."},"0a55223a8807dfafc4e957899053f571":{"type":"string","example":"Silver","can_have_multiple_values":false,"fieldname":"PlatingMaterial","key":"plating_material","recommended":false,"description":"The type of metal or material which your item is plated or covered with."},"deb41e4835824a3ada806d318df5ffe0":{"type":"string","example":"14k","can_have_multiple_values":false,"fieldname":"MetalStampOrPurity","key":"metal_stamp_or_purity","recommended":false,"description":"The metal purity of your item. Sometimes this is indicated or stamped directly onto jewelry items."},"6e7562a9f0a1c4675f7ca5d15cf53e6a":{"type":"string","example":"2 prong","can_have_multiple_values":false,"fieldname":"JewelrySettingStyle","key":"jewelry_setting_style","recommended":false,"description":"The style in which stones are set within or attached to a piece of jewelry"},"f0f118d833eecf0a3d4deb47ce1e8a2a":{"type":"string","example":["Best Friends Forever"],"can_have_multiple_values":true,"fieldname":"Inscription","key":"inscription","recommended":false,"description":"The text of what is engraved on the item. (Multiple Values Accepted)"},"3ed35b95494c9b3f2985fdb9dff7730d":{"type":"string","example":1.29,"can_have_multiple_values":false,"fieldname":"GemstoneWeight","key":"gemstone_weight","recommended":false,"description":"The total weight or mass (in carats) of the individual gemstone."},"58ba4a0325e3756373a8383a2bc5377d":{"type":"string","example":5,"can_have_multiple_values":false,"fieldname":"GemstoneWidth","key":"gemstone_width","recommended":false,"description":"The width measurement of the gemstone in milimeters."},"8e0135de1890e1bc54c6f4524d2bb6a1":{"type":"string","example":["Dyed","Heat Treated"],"can_have_multiple_values":true,"fieldname":"GemstoneTreatment","key":"gemstone_treatment","recommended":false,"description":"Indicates any treatments or processing of the stone to change its color, clarity or durability."},"af11df6c0242d4276dc13b175379b723":{"type":"string","example":5,"can_have_multiple_values":false,"fieldname":"GemstoneLength","key":"gemstone_length","recommended":false,"description":"The length measurement of the gemstone in milimeters."},"8f70200f0fd2e1a7987947575021f910":{"type":"string","example":5,"can_have_multiple_values":false,"fieldname":"GemstoneHeight","key":"gemstone_height","recommended":false,"description":"The height measurement of the gemstone in milimeters."},"6ad2f369b3c9e5177d46ce54aaa855e3":{"type":"string","example":"Asscher","can_have_multiple_values":false,"fieldname":"GemstoneCut","key":"gemstone_cut","recommended":false,"description":"The style in which the gemstone(s) of your item have been cut and their general shape."},"be0f716b198ea39563b1ae49c03feaa7":{"type":"string","example":"Natural","can_have_multiple_values":false,"fieldname":"GemstoneCreationMethod","key":"gemstone_creation_method","recommended":false,"description":"The method by which the stone was created. Indicates if the stone is natural or manmade."},"087b63be2ec0b2c73fdeb21260a8429e":{"type":"string","example":"Colorless","can_have_multiple_values":false,"fieldname":"GemstoneColor","key":"gemstone_color","recommended":false,"description":"The color of the gemstone(s) in your item that accounts for hue, tone and saturation."},"40496e7589d7a3e945471afaa9b5eb77":{"type":"string","example":"FL","can_have_multiple_values":false,"fieldname":"GemstoneClarity","key":"gemstone_clarity","recommended":false,"description":"The quality and clarity of the visual aspect of the gemstone, particularly important for Diamonds. Indicates visual and and internal characteristics and surface defects of blemishes."},"3b714bc4f27197b27df4ed555063b227":{"type":"string","example":"Clip-On","can_have_multiple_values":false,"fieldname":"EarringBackFinding","key":"earring_back_finding","recommended":false,"description":"The type of fastening method for the backs of earrings."},"2a4450be3608cf3a38cad25f7d49b813":{"type":"string","example":"Lobster Clasp","can_have_multiple_values":false,"fieldname":"ClaspType","key":"clasp_type","recommended":false,"description":"The type of clasp or closure method of your item."},"b8b24c8698213706e91fb53948de8a69":{"type":"measurement","example":"12 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"ChainLength","key":"chain_length","recommended":false,"description":"The length of the jewelry chain. Usually in inches."},"2ad129e62056d93bd1201aef398651bb":{"type":"string","example":1.29,"can_have_multiple_values":false,"fieldname":"TotalGemstoneWeight","key":"total_gemstone_weight","recommended":false,"description":"The total combined weight or mass (in carats) of all stones in the piece of jewelry."},"d9e0fd21a2211dee29551f555ae1036d":{"type":"string","example":["Bangle"],"can_have_multiple_values":true,"fieldname":"Style","key":"style","recommended":true,"description":"The style(s) associated with the item."},"cf48a2e1304c7e8e3df5e6a9eb67e991":{"type":"enum","example":"Electric","can_have_multiple_values":false,"enum_values":["Electric","Batteries"],"can_have_unknown_value":true,"fieldname":"PowerType","key":"power_type","recommended":false,"description":"Provides information on the exact type of power used by the item."},"abfc9636c9dd70941b01e4e077588073":{"type":"enum","example":["Calendar"],"can_have_multiple_values":true,"enum_values":["Calendar","Resizable","Water Resistant","Waterproof"],"can_have_unknown_value":false,"fieldname":"StandardFeatures","key":"standard_features","recommended":false,"description":"Standard features related to your item that might be important for buyers."},"0f94d987d41ce3cc234ca9051c468234":{"type":"measurement","example":"240 mm","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"WatchBandLength","key":"watch_band_length","recommended":false,"description":"The length of the watch band"},"8ea77ea069e2c0b4b74c167d9e394faf":{"type":"string","example":["Leather","Stainless Steel"],"can_have_multiple_values":true,"fieldname":"WatchBandMaterial","key":"watch_band_material","recommended":false,"description":"The primary material(s) from which the band of the watch is made."},"d3ac14e44af9ea925fd801578da42a63":{"type":"measurement","example":"22 mm","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"WatchBandWidth","key":"watch_band_width","recommended":false,"description":"The width of the watch band"},"028cde57179c9c4356a63649d170c6c4":{"type":"measurement","example":"42 mm","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"WatchCaseDiameter","key":"watch_case_diameter","recommended":false,"description":"The diameter of the watch case or dial"},"f4b65f0456fd44dd79accf30fa6002f6":{"type":"string","example":"Round","can_have_multiple_values":false,"fieldname":"WatchCaseShape","key":"watch_case_shape","recommended":false,"description":"The shape of the watch case or enclosure which contains the face & inner workings of the watch."},"37da4cf70f57a2eaf2671145d216b16e":{"type":"measurement","example":"12 mm","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"WatchCaseThickness","key":"watch_case_thickness","recommended":false,"description":"The thickness of the watch case or dial"},"eba94cf3d4446cdb773987c97f384918":{"type":"string","example":["Yoga","Sailing"],"can_have_multiple_values":true,"fieldname":"Activity","key":"activity","recommended":false,"description":"The particular sport or activity for which your item is intended."},"44084d5972f3b03d6abe5887c6dfd4b0":{"type":"string","example":["Ruby","Emerald"],"can_have_multiple_values":true,"fieldname":"Gemstone","key":"gemstone","recommended":false,"description":"The type of gemstone(s) in your item."},"9a6f633320e996ae1d5bad38d51e085c":{"type":"string","example":"Quartz","can_have_multiple_values":false,"fieldname":"WatchMovementType","key":"watch_movement_type","recommended":false,"description":"The type of movement within the watch"},"fe4c9e79e3986fe439f5ba1c21828f2e":{"type":"measurement","example":"1 TB","enum_values":["KB","MB","GB","TB"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"StorageCapacity","key":"storage_capacity","recommended":true,"description":"Describes the amount of storage space on the item's hard drive, typically measured in megabytes, gigabytes or terabytes."},"2390176fad8a47f031329e771da0e400":{"type":"string","example":"Android","can_have_multiple_values":false,"fieldname":"OperatingSystem","key":"operating_system","recommended":true,"description":"Describes the type of preloaded operating system software installed on the device."},"49b1cf42befb0ba138e430326fbc6ea6":{"type":"measurement","example":"42 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"ScreenSize","key":"screen_size","recommended":true,"description":"Describes the measurement of the device's screen, typically measured diagonally in inches."},"567aba0d72ce14b0928d5e6aa61c7f35":{"type":"string","example":24,"can_have_multiple_values":false,"fieldname":"RearFacingCameraResolution","key":"rear_facing_camera_resolution","recommended":false,"description":"Describes the maximum resolution of the item's rear facing camera, in megapixels."},"a5dc22c3e935ab432331f4cab30c0787":{"type":"measurement","example":"3 GHz","enum_values":["Hz","KHz","MHz","GHz"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"ProcessorSpeed","key":"processor_speed","recommended":false,"description":"Describes the operational frequency of the computer's CPU"},"361b07f5140feaec4be03122ed0d6287":{"type":"string","example":"Intel Core i7","can_have_multiple_values":false,"fieldname":"ProcessorType","key":"processor_type","recommended":false,"description":"Describes commonly used name of the computer's CPU"},"fe18897b738f817319015eb3048928e5":{"type":"measurement","example":"16 GB","enum_values":["KB","MB","GB","TB"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"RamMemory","key":"ram_memory","recommended":false,"description":"Desribes the amount of RAM memory that is preinstalled on the product."},"083cb9b61b45283ca9ee93f906516300":{"type":"integer","example":1080,"can_have_multiple_values":false,"fieldname":"Resolution","key":"resolution","recommended":false,"description":"Describes the resolution of the product screen"},"a59afd07b13fe423f4ea99faec8453d8":{"type":"string","example":24,"can_have_multiple_values":false,"fieldname":"VideoResolution","key":"video_resolution","recommended":false,"description":"Describes the resolution of the video recordings of the product in\n        megapixels"},"3b621ecd047fb5f084be32fc1afb6389":{"type":"string","example":"ATX","can_have_multiple_values":false,"fieldname":"MotherboardFormFactor","key":"motherboard_form_factor","recommended":false,"description":"Describes one of the standard physical sizes to which the computer motherboard conforms"},"bfe5d2ed096364fe145cc59a87f41760":{"type":"string","example":["CD ROM"],"can_have_multiple_values":true,"fieldname":"OpticalDrive","key":"optical_drive","recommended":false,"description":"Describes the type of optical drives included with the product"},"ec6456439bf772caeb9e8304cb32ec3e":{"type":"measurement","example":"16 GB","enum_values":["KB","MB","GB","TB"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"MaximumSupportedRam","key":"maximum_supported_ram","recommended":false,"description":"Describes the maximum amount of RAM memory that can be supported by the product."},"70d088a2087eeddc317dedc4846e71e1":{"type":"enum","example":"Internal","can_have_multiple_values":false,"enum_values":["Internal","External"],"can_have_unknown_value":true,"fieldname":"HardDriveType","key":"hard_drive_type","recommended":false,"description":"Describes whether the hard drives of the product are internal or external"},"4a2d5d0019d9f4e3e553461d450eb409":{"type":"string","example":"Nvidia GeForce RTX 2080","can_have_multiple_values":false,"fieldname":"GraphicsCardModel","key":"graphics_card_model","recommended":false,"description":"Describes the model name of the graphics card included with the product"},"ea1ec0d2e16be590eee6a2ede6da6435":{"type":"string","example":24,"can_have_multiple_values":false,"fieldname":"FrontFacingCameraResolution","key":"front_facing_camera_resolution","recommended":false,"description":"Describes the maximum resolution of the item's front facing camera, in megapixels."},"b6049f7a7d322c6402d8e55ff0041d93":{"type":"string","example":"AM3","can_have_multiple_values":false,"fieldname":"CpuSocketType","key":"cpu_socket_type","recommended":false,"description":"The interface of, or required by, the central processing unit."},"54919ad5f3d7792c8e13c4bde36632bf":{"type":"string","example":"Full Tower","can_have_multiple_values":false,"fieldname":"ComputerCaseFormFactor","key":"computer_case_form_factor","recommended":false,"description":"Describes one of the standard physical sizes to which the computer case conforms"},"b31777d6275a27c26f1e9928c503ef19":{"type":"string","example":"Bluetooth 4.0","can_have_multiple_values":false,"fieldname":"BluetoothTechnology","key":"bluetooth_technology","recommended":false,"description":"Describes the type of version of the compatible bluetooth."},"dacac94d354a921cff590fa3d34d6078":{"type":"string","example":12,"can_have_multiple_values":false,"fieldname":"StandbyTime","key":"standby_time","recommended":false,"description":"Describes the total stand-by time in hours of the phone."},"ed57863b87213a9ffe54d40f978635b8":{"type":"string","example":12,"can_have_multiple_values":false,"fieldname":"TalkTime","key":"talk_time","recommended":false,"description":"Describes the total talk time in hours of the phone."},"643ec7fd851671f9f0fe60199b37bf0c":{"type":"string","example":["Leather"],"can_have_multiple_values":true,"fieldname":"WatchBandMaterial","key":"watch_band_material","recommended":false,"description":"The materials from which the band of the watch is made."},"d0aae07685ed17d8f4d00a2658fbb437":{"type":"string","example":["Standard SIM"],"can_have_multiple_values":true,"fieldname":"SimTypes","key":"sim_types","recommended":false,"description":"Describes the type of SIM compatible with the product, like Mini-SIM, Dual SIM."},"f2d22b905571ec1b0c9722ed6c227125":{"type":"integer","example":1,"can_have_multiple_values":false,"fieldname":"NumberofSIMCardSlots","key":"numberof_s_i_m_card_slots","recommended":false,"description":"Describes the number of SIM card slots on the product."},"7c8efd858532f7cdf437cc9fb39a0bec":{"type":"string","example":"3G","can_have_multiple_values":false,"fieldname":"CellularGeneration","key":"cellular_generation","recommended":false,"description":" Describes the communications network generation of the cell phone"},"65fe00497801a23a1285c1bdfba66014":{"type":"string","example":"CDMA","can_have_multiple_values":false,"fieldname":"CellularBand","key":"cellular_band","recommended":false,"description":"Describes the cellular band or network technology used by the device."},"fe1280e0d1b522e738d01296e5efb34f":{"type":"string","example":"Verizon","can_have_multiple_values":false,"fieldname":"CellPhoneServiceProvider","key":"cell_phone_service_provider","recommended":false,"description":"Describes the company that provides the phone's cellular service (if not unlocked)"},"bbc7f8045d5073625f856ac52313df47":{"type":"string","example":"Wristwatch","can_have_multiple_values":false,"fieldname":"WatchStyle","key":"watch_style","recommended":false,"description":"The style of watch."},"707d4ddb458001de9dd489dc081a917a":{"type":"string","example":["iPad"],"can_have_multiple_values":true,"fieldname":"CompatibleDevices","key":"compatible_devices","recommended":true,"description":"Devices compatible with the item."},"30c69d289f07754985fa521022655ba0":{"type":"measurement","example":"10 g","enum_values":["mg","g","kg","oz","lb"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"ProductWeight","key":"product_weight","recommended":false,"description":"The weight of the fully assembled product."},"10a6af510a4d49ca6eeaebfbead6c6fa":{"type":"measurement","example":"40 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"MinimumScreenSize","key":"minimum_screen_size","recommended":false,"description":" Describes the minimum size of the TV\/Monitor that the mount can\n          accommodate"},"b1bac032a961eb0cff6df86fce2da4c4":{"type":"string","example":"Fixed Mount","can_have_multiple_values":false,"fieldname":"MountType","key":"mount_type","recommended":false,"description":"Describes how the TV or monitor is attached and degree of\n        adjustment of position is allowed once the mount is installed"},"bdcaca96c46e181c0d4bf347097c228e":{"type":"measurement","example":"55 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"MaximumScreenSize","key":"maximum_screen_size","recommended":false,"description":"Describes the maximum size of the TV\/Monitor that the mount can\n          accommodate"},"ec7db52e6443df6d84672fa3397e4144":{"type":"measurement","example":"45 lb","enum_values":["mg","g","kg","oz","lb"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"MaxLoadWeight","key":"max_load_weight","recommended":false,"description":"Describes the amount of weight that the TV\/Monitor mount\n        can support as certified by the manufacturer"},"91f569f41bdde8d40c421f04d9f0ec23":{"type":"string","example":["In-Ear"],"can_have_multiple_values":true,"fieldname":"HeadphoneFeatures","key":"headphone_features","recommended":false,"description":"List features specific to headphones"},"158bcad2efdd1b1f944e632d8603c189":{"type":"measurement","example":"2 ft","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"CableLength","key":"cable_length","recommended":false,"description":"Total length of electronics cable"},"8904e34635ccfa9f1776f6bf8964d571":{"type":"measurement","example":"10 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"ProductDepth","key":"product_depth","recommended":true,"description":"The depth of the fully assembled product."},"1e86882555078459f4919858583e9fce":{"type":"integer","example":1080,"can_have_multiple_values":false,"fieldname":"Resolution","key":"resolution","recommended":true,"description":"Describes the resolution of the product screen"},"75bf93f645a2702cd3dc1aeac96fcc79":{"type":"integer","example":50,"can_have_multiple_values":false,"fieldname":"MonochromePagesPerMinute","key":"monochrome_pages_per_minute","recommended":false,"description":"The number of monochrome pages that the imaging device is able to produce per minute."},"bf9c9a51c205f8c02070a7aa2e11d65b":{"type":"enum","example":"Monochrome","can_have_multiple_values":false,"enum_values":["Monochrome","Color"],"can_have_unknown_value":true,"fieldname":"MonochromeOrColor","key":"monochrome_or_color","recommended":false,"description":"Is the imaging device capable of color processing or monochrome only?"},"eefa8dd52fadfc95322a8c584a87e1c5":{"type":"integer","example":12,"can_have_multiple_values":false,"fieldname":"ColorPagesPerMinute","key":"color_pages_per_minute","recommended":false,"description":"The number of color pages that the imaging device is able to produce per minute."},"be84c1ccb42a2826aa12efb3ad494d6e":{"type":"string","example":"LCD","can_have_multiple_values":false,"fieldname":"DisplayTechnology","key":"display_technology","recommended":true,"description":"Describes the type of technology that powers the display, like LED or LCD."},"fece1f8c30e55cec967050c8d46d2179":{"type":"string","example":5,"can_have_multiple_values":false,"fieldname":"ResponseTime","key":"response_time","recommended":false,"description":"Describes the amount of time it takes for the pixels in a display to change, measured in miliseconds."},"d2b0fda41f2dc69846c9a72ee97b6304":{"type":"string","example":60,"can_have_multiple_values":false,"fieldname":"RefreshRate","key":"refresh_rate","recommended":false,"description":"Describes the refresh rate of the display. This measures the number of times the picture is updated per second, measured in Hz."},"0307a27632bdff957e247336e336c958":{"type":"string","example":"200 x 200","can_have_multiple_values":false,"fieldname":"VesaMountingStandard","key":"vesa_mounting_standard","recommended":false,"description":"The VESA Standard defines the distance in millimeters between the\n          four mounting holes on the back of a TV (distance horizontally x\n          distance vertically)."},"0ea98808c27886d1dae8ceaa3aaa2260":{"type":"string","example":"4:3","can_have_multiple_values":false,"fieldname":"AspectRatio","key":"aspect_ratio","recommended":false,"description":"Describes the relationship between the product's width and its height."},"0abb978f2c8edd1d059e564a4e41e744":{"type":"integer","example":3,"can_have_multiple_values":false,"fieldname":"NumberOfHdmiports","key":"number_of_hdmiports","recommended":false,"description":"The number of HDMI ports on the television or monitor"},"82229416d35b701d3f141174aa5f054b":{"type":"string","example":"20,000:1","can_have_multiple_values":false,"fieldname":"MaximumContrastRatio","key":"maximum_contrast_ratio","recommended":false,"description":"The ratio between the luminance of the brightest color to that of\n        the darkest color capable of being displayed."},"2da53aa14b92ca922b59fdea5a6a69d6":{"type":"boolean","example":"yes","can_have_multiple_values":false,"can_have_unknown_value":false,"enum_values":["yes","no"],"fieldname":"IsAssemblyRequired","key":"is_assembly_required","recommended":false,"description":"Indicates if the product arrives unassembledand must be put together before use."},"6fa83aef4f8623080b9b36b3373d650f":{"type":"string","example":"CCFL","can_have_multiple_values":false,"fieldname":"BacklightTechnology","key":"backlight_technology","recommended":false,"description":"Describes the technology used to backlight the screen or television. Commonly Cathold Fluorescent Tubes (CCFL) or Light Emitting Diodes (LED)"},"459473687330b5617bdaf470bcf83a7e":{"type":"string","example":5,"can_have_multiple_values":false,"fieldname":"AudioPowerOutput","key":"audio_power_output","recommended":false,"description":"Describes the power of the audio output of the device's speakers, measured in watts."},"81c8727757c4fd1d1d12f5d261744c57":{"type":"string","example":["Noise Cancelling"],"can_have_multiple_values":true,"fieldname":"AudioFeatures","key":"audio_features","recommended":false,"description":"Describes whether the product has certain special audio features."},"1e2de3306f34ebe0755bb8f5297f9cb0":{"type":"string","example":1.8,"can_have_multiple_values":false,"fieldname":"ThrowRatio","key":"throw_ratio","recommended":false,"description":"The relation between the throw distance and the image width; tells\n          us what image size we can project from a certain distance away."},"755632f8c8070139f1d7b1d8817eeac3":{"type":"string","example":6500,"can_have_multiple_values":false,"fieldname":"LampLife","key":"lamp_life","recommended":false,"description":"The expected life of the projection lamp in hours."},"697539305c05f8a9a0fe6e97e2eab4d0":{"type":"string","example":2000,"can_have_multiple_values":false,"fieldname":"Brightness","key":"brightness","recommended":false,"description":"Brightness per bulb measured in lumens."},"fba4b5b5f790c6348fabe6c10d0f8bf6":{"type":"string","example":"Xbox 360","can_have_multiple_values":false,"fieldname":"VideoGamePlatform","key":"video_game_platform","recommended":true,"description":"Describes the type of platform on which video game software is capable of running."},"01691d8e5b9ed5a58a109dc90b74f439":{"type":"string","example":"Fallout","can_have_multiple_values":false,"fieldname":"VideoGameSeries","key":"video_game_series","recommended":false,"description":"The name of the video game series this game belongs to."},"ecb8b647ae87edddac43b94a3093e72c":{"type":"string","example":"E - Everyone","can_have_multiple_values":false,"fieldname":"VideoGameRating","key":"video_game_rating","recommended":false,"description":"Describes the standard rating of the content of the video game. Can be important for violent games or games intended only for mature audiences."},"532c713f0d2a4408702814f32c02020f":{"type":"string","example":"Shooter","can_have_multiple_values":false,"fieldname":"VideoGameGenre","key":"video_game_genre","recommended":false,"description":"Describes the genre, style or type of video game being sold."},"e65585ff17b284d24ee18e28851f6ac8":{"type":"measurement","example":"1 TB","enum_values":["KB","MB","GB","TB"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"StorageCapacity","key":"storage_capacity","recommended":false,"description":"Describes the amount of storage space on the item's hard drive, typically measured in megabytes, gigabytes or terabytes."},"9a9c97dfb6df9491e73d4ba7d39e2460":{"type":"string","example":["Kinect"],"can_have_multiple_values":true,"fieldname":"RequiredPeripherals","key":"required_peripherals","recommended":false,"description":"Indicates any type of required accessory or peripheral necessary to operate the item (or play the video game)."},"a36f46f58ba3a8907408d6c24e50bfad":{"type":"string","example":"09-19-2019","can_have_multiple_values":false,"fieldname":"ReleaseDate","key":"release_date","recommended":false,"description":"Describes the specific date which marks when the product was made available for public distribution, provided in the format MM-DD-YYYY"},"48504b28464be452dc971f271b0eef35":{"type":"string","example":"CD","can_have_multiple_values":false,"fieldname":"PhysicalMediaFormat","key":"physical_media_format","recommended":false,"description":"Describes the standard media format in which the product exists."},"95f1c14e6ac4218a6af57710a935fb6f":{"type":"string","example":"Android","can_have_multiple_values":false,"fieldname":"OperatingSystem","key":"operating_system","recommended":false,"description":"Describes the type of preloaded operating system software installed on the device."},"87ee129e6abae679ef3dc1881c29ac4c":{"type":"string","example":"Natural\/Unfinished","can_have_multiple_values":false,"fieldname":"Finish","key":"finish","recommended":true,"description":"The external treatment to the productthat usually includes a change inappearance or texture to the item.Commonly used for furniture includewood, metal and fabric."},"73c8639362fab24e43a3fa21a122d3f6":{"type":"string","example":"Bohemian","can_have_multiple_values":false,"fieldname":"DecorStyle","key":"decor_style","recommended":true,"description":"The decorative style in which the product was made."},"9c05349004f01b710d863a5bcc135754":{"type":"string","example":["Designer"],"can_have_multiple_values":true,"fieldname":"AdditionalFeatures","key":"additional_features","recommended":false,"description":"Additional features related to your item that might be important for buyers."},"447e1ca997ac7372d84321a5da8b9577":{"type":"string","example":["Family Room"],"can_have_multiple_values":true,"fieldname":"RecommendedRooms","key":"recommended_rooms","recommended":false,"description":"The rooms where the item is likely or recommended to be used."},"cb8a3c1875a379537c185708e6662ba6":{"type":"measurement","example":"20 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"SeatBackHeight","key":"seat_back_height","recommended":false,"description":"Indicates the seat back height from the base of the seat to the top of the back. This may be separate from the \"Assembled Product Height\" and \"Seat Height\" attributes."},"ed80e4f1f84fcb9b076e9089aa9b73da":{"type":"measurement","example":"36 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"SeatHeight","key":"seat_height","recommended":false,"description":"Indicates height from the floor to the top of the seat. This may be separate from the \"Assembled Product Height\" and \"Seat Back Height\" attributes."},"eaf4eb99a4c71f786c74f207839181ab":{"type":"string","example":"Leather","can_have_multiple_values":false,"fieldname":"SeatMaterial","key":"seat_material","recommended":false,"description":"The material of the item's seat cushion. This may be separate from the item's main material composition, which falls under the \"Material\" attribute."},"f2d839922ab1a15c3720eb42f01393ff":{"type":"string","example":"Square","can_have_multiple_values":false,"fieldname":"Shape","key":"shape","recommended":false,"description":"The general shape of the product. Often used to describe\n        furniture and home furnishings."},"00d4ef3a1bb967e59e960f07a8a36010":{"type":"enum","example":["Antique"],"can_have_multiple_values":true,"enum_values":["Foldable","Inflatable","Pump Included","Wheeled","Antique"],"can_have_unknown_value":false,"fieldname":"StandardFeatures","key":"standard_features","recommended":false,"description":"Standard features related to your item that might be important for buyers."},"2733dc5d8c97d75657a86568037a0609":{"type":"integer","example":4,"can_have_multiple_values":false,"fieldname":"NumberOfDrawers","key":"number_of_drawers","recommended":false,"description":"The number of drawers included in the product."},"9e1903c5cd2876e1c9889eb5cea8045a":{"type":"integer","example":4,"can_have_multiple_values":false,"fieldname":"NumberOfShelves","key":"number_of_shelves","recommended":false,"description":"The number of shelves included in the product."},"8cafc76619e3f64c83abec41a95b9915":{"type":"string","example":"Wall Mount","can_have_multiple_values":false,"fieldname":"MountType","key":"mount_type","recommended":false,"description":"The method by which the item is attached or anchored. Used for products such as shelving and other fixtures."},"97bdb9242e7b2962284619b2ce7c06a4":{"type":"measurement","example":"10 in","enum_values":["mm","cm","m","in","ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"MattressThickness","key":"mattress_thickness","recommended":false,"description":"The measure from the bottom of the mattress to the crown"},"a700f8e116174455d5d9f3782aa0bf4e":{"type":"boolean","example":"yes","can_have_multiple_values":false,"can_have_unknown_value":false,"enum_values":["yes","no"],"fieldname":"IsPowered","key":"is_powered","recommended":false,"description":"Indicates if the item uses electricity and requires a power cord or batteries to operate."},"7f54c0815b0e8d9cb192bdc4819bd7f5":{"type":"enum","example":"Indoor Only","can_have_multiple_values":false,"enum_values":["Indoor Only","Outdoor Only","Indoor\/Outdoor"],"can_have_unknown_value":true,"fieldname":"IndoororOutdoor","key":"indooror_outdoor","recommended":false,"description":"Indicates if the item is indoor only, outdoor only, or intended for both."},"39a086121f568673a43aedb5478c26d4":{"type":"string","example":"Foam","can_have_multiple_values":false,"fieldname":"FillMaterial","key":"fill_material","recommended":false,"description":"The material used to stuff the item usually in cushions, pillows,\n          mattresses, and bean bags."},"d17ad1a388d5c83e6d89a16d3ac964fb":{"type":"string","example":"Extra Firm","can_have_multiple_values":false,"fieldname":"ComfortLevel","key":"comfort_level","recommended":false,"description":"The firmness or softness of a mattress."},"9d73d1c85fae03275869c6806d30fd93":{"type":"string","example":"Canopy Bed","can_have_multiple_values":false,"fieldname":"BedFrameType","key":"bed_frame_type","recommended":false,"description":"The type or style of the bed. Does not include Futons, Day Beds, or Sleepers."},"7d8fefe9bf9918c271f908a0e83f5f16":{"type":"enum","example":["Wheeled"],"can_have_multiple_values":true,"enum_values":["Foldable","Wheeled","Antique"],"can_have_unknown_value":false,"fieldname":"StandardFeatures","key":"standard_features","recommended":false,"description":"Standard features related to your item that might be important for buyers."},"e009f02a406e7aab29c5ab8230d08848":{"type":"string","example":"Natural\/Unfinished","can_have_multiple_values":false,"fieldname":"Finish","key":"finish","recommended":false,"description":"The external treatment to the productthat usually includes a change inappearance or texture to the item.Commonly used for furniture includewood, metal and fabric."},"13828083302ba311fdebc396a1610bf6":{"type":"string","example":["Fever"],"can_have_multiple_values":true,"fieldname":"HealthConcern","key":"health_concern","recommended":true,"description":"Indicates if the item is meant to alleviate particular health issues, illnesses or life stages. For concerns specific to skin care, please use the Skin Care Concern attribute."},"11f3261c7ccebb79e06751f778d5d4ab":{"type":"measurement","example":"12 oz","enum_values":["ml","l","oz","cu_ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"Capacity","key":"capacity","recommended":true,"description":"Indicates the capacity or volume of your item. This is important for buyers to know the amount of product they are receiving and is important for skin care, beauty & hair care products."},"2d80b0c58142a82357f2d2fdfafd9068":{"type":"string","example":["Beeswax"],"can_have_multiple_values":true,"fieldname":"Ingredients","key":"ingredients","recommended":true,"description":"The list of all ingredients contained in an item, as found on the product label mandated by FDA guidelines."},"365ecf662d48185b92a5aa253d935173":{"type":"string","example":"3 to 5 hours","can_have_multiple_values":false,"fieldname":"ResultTime","key":"result_time","recommended":false,"description":"Duration of time necessary to see the outcome from using a product. Typically used for medical and personal care test kits and monitors."},"7699774215529bc8717eb00ce738c58a":{"type":"string","example":"Heavy","can_have_multiple_values":false,"fieldname":"Absorbency","key":"absorbency","recommended":false,"description":"Term describing the ability of a product to absorb moisture. Used in personal care products such as pads and liners."},"2639fc784370fb97d9a426b33e6eff0e":{"type":"measurement","example":"0.4 ml","enum_values":["ml","l","oz","cu_ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"ServingSize","key":"serving_size","recommended":false,"description":"Measurement value specifying the amount of the item typically used as a reference on the label of that item to list per serving information (nutrients, calories, total fat). Applicable for a wide variety of products including food, beverages, and nutritional supplements."},"336df2b3fca4bc8318f7589b8c888d03":{"type":"string","example":["Dry Skin"],"can_have_multiple_values":true,"fieldname":"SkinCareConcern","key":"skin_care_concern","recommended":false,"description":"Indicates if the item is meant to alleviate particular skin care issues. For general health concerns like obesity, or blood pressure please use the Health Concerns attribute. Values may be similar to the Skin Type attribute - \"dry cracked skin\" may be a cocnern but \"dry\" is a skin type."},"eba9b3d21340c3ed25d6778417988888":{"type":"enum","example":"Oily","can_have_multiple_values":false,"enum_values":["Oily","Dry","Combination","Sensitive"],"can_have_unknown_value":true,"fieldname":"SkinType","key":"skin_type","recommended":false,"description":"Indicates the general skin type that the product is intended for on the oily\/dry spectrum."},"cffbfe91501fcda43b326b2797a39ee0":{"type":"integer","example":15,"can_have_multiple_values":false,"fieldname":"SpfValue","key":"spf_value","recommended":false,"description":"Indicates the strength of SPF (Sun Protection Factor) in an item. This describes how well the product can block out harmful rays from the run. Commonly found in suncreen and makeup products."},"4f2642a8dcd42338499b2aa75ffca1fe":{"type":"enum","example":["Reusable"],"can_have_multiple_values":true,"enum_values":["Adaptive Lenses","Automatic Shut Off","Cordless","Foldable","Industrial","Latex-Free","Non-Comedogenic","Portable","Polarized","Reusable","Self-Tanning","Tinted","Travel Size","Waterproof","Wheeled","Scratch-Resistant"],"can_have_unknown_value":false,"fieldname":"StandardFeatures","key":"standard_features","recommended":false,"description":"Standard features related to your item that might be important for buyers."},"78aba0a00b3412827370aede724962dc":{"type":"string","example":["Plastic"],"can_have_multiple_values":true,"fieldname":"LensMaterial","key":"lens_material","recommended":false,"description":"The substances an optical lens is made out of."},"e6041e1b82f9e3ac106d984107d13504":{"type":"string","example":"Single Vision","can_have_multiple_values":false,"fieldname":"LensType","key":"lens_type","recommended":false,"description":"Whether the lens is single, multifocal, or tinted"},"937f3f40d16b2b5a23052e2d7311c6ff":{"type":"string","example":"Blue","can_have_multiple_values":false,"fieldname":"LensTint","key":"lens_tint","recommended":false,"description":"Color of lens tint."},"8b4897149a7b0cf1c4b79f6ca7c03881":{"type":"string","example":["Solid"],"can_have_multiple_values":true,"fieldname":"Keywords","key":"keywords","recommended":false,"description":"Keywords that might be used to search for this term, including synonyms and related terms."},"830b557ebbb8f05aa8d8e89c8073c9d8":{"type":"string","example":[{"name":"Pyrithione zinc","amount":2.5},{"name":"Salicylic Acid","amount":2}],"can_have_multiple_values":false,"fieldname":"IngredientsComposition","key":"ingredients_composition","recommended":false,"description":"The ingredients with the corresponding composition value"},"45f47b75dfc8dcab7bcc1b6895c572a0":{"type":"string","example":["Iron Oxide"],"can_have_multiple_values":true,"fieldname":"InactiveIngredients","key":"inactive_ingredients","recommended":false,"description":"Describes the list of inactive ingredients as shown on the item label."},"a416c6be2906ac2830fbd812fba3e591":{"type":"enum","example":"Full-Rim","can_have_multiple_values":false,"enum_values":["Full-Rim","Rimless","Semi-Rimless","Half-Rim"],"can_have_unknown_value":true,"fieldname":"EyewearRim","key":"eyewear_rim","recommended":false,"description":"Whether eyewear has rims, partial rims, or no rim at all."},"f4b8e7636597b2b532f6c75c8bd2a7a9":{"type":"string","example":["1 teaspoon every 6 hours"],"can_have_multiple_values":true,"fieldname":"Dosage","key":"dosage","recommended":false,"description":"The amount of a medication, drug, or supplement that is directed to be taken, or applied at one time or regularly during a period of time, as specified by the manufacturer."},"91455c53f237eb64c3de88f2c35b9556":{"type":"string","example":["Eyes","Face"],"can_have_multiple_values":true,"fieldname":"BodyPart","key":"body_part","recommended":false,"description":"Describes the particular body part(s) for which the item is intended."},"007e22a1352c2d2a1a443ba90e14b127":{"type":"boolean","example":"yes","can_have_multiple_values":false,"can_have_unknown_value":false,"enum_values":["yes","no"],"fieldname":"BatteriesRequired","key":"batteries_required","recommended":false,"description":"Indicates if batteries are required to use the product."},"052d7ff877183c9dcce5362a73e73428":{"type":"integer","example":400,"can_have_multiple_values":false,"fieldname":"UVRating","key":"u_v_rating","recommended":false,"description":"Ultraviolet rating for eyewear."},"3308f187f85aeefe4d6ed8fc5cd8e8e6":{"type":"enum","example":"Fair","can_have_multiple_values":false,"enum_values":["Fair","Light","Medium","Neutral","Olive","Dark"],"can_have_unknown_value":true,"fieldname":"SkinTone","key":"skin_tone","recommended":false,"description":"Describes the color or shade of skin that a product is targeted for. This is separate from Color Name of the product. \"Olive\" may be a color name from the manufacturer as well as the type of skin tone the product is targeting."},"9a04dccec14d02d689cf02fb757d1a10":{"type":"string","example":["Beeswax"],"can_have_multiple_values":true,"fieldname":"InactiveIngredients","key":"inactive_ingredients","recommended":false,"description":"Describes the list of inactive ingredients as shown on the item label."},"896fe12fa920abf8d338cef50e162628":{"type":"string","example":["Fever"],"can_have_multiple_values":true,"fieldname":"HealthConcern","key":"health_concern","recommended":false,"description":"Indicates if the item is meant to alleviate particular health issues, illnesses or life stages. For concerns specific to skin care, please use the Skin Care Concern attribute."},"3456eaf701f7278c2be139c78bcabd3f":{"type":"enum","example":["Coarse"],"can_have_multiple_values":true,"enum_values":["Coarse","Color Treated","Curly","Damaged","Dry","Fine","Oily"],"can_have_unknown_value":false,"fieldname":"HairType","key":"hair_type","recommended":false,"description":"Indicates the general hair types that the product is intended for relating to texture, coarseness, oiliness, thickness, and curliness."},"ce6ffae63aa69791f8881e7fb7c2bea8":{"type":"string","example":["Wash with warm water & soap"],"can_have_multiple_values":true,"fieldname":"CareInstructions","key":"care_instructions","recommended":false,"description":"Describes how the item should be cleaned, cared for or maintained."},"f7cdf1aaddb5d5cf96bdc35a3f9ba7c7":{"type":"string","example":"100% Hand-Tied","can_have_multiple_values":false,"fieldname":"WigCapType","key":"wig_cap_type","recommended":false,"description":"The construction style of the wig cap (also called the \"wig base\"), affecting the wig's appearance, durability, and styling options."},"16f4737bd60328d18f404968ba09f5de":{"type":"enum","example":["Automatic Shut Off"],"can_have_multiple_values":true,"enum_values":["Automatic Shut Off","Energy Star-Certified"],"can_have_unknown_value":false,"fieldname":"StandardFeatures","key":"standard_features","recommended":false,"description":"Standard features related to your item that might be important for buyers."},"ecb45e77061f56ea0bf5ab6280fd7b6d":{"type":"integer","example":1,"can_have_multiple_values":false,"fieldname":"NumberofLights","key":"numberof_lights","recommended":false,"description":"The number of lights or bulbs contained within a light or light fixture."},"884e05ecb296a36e8e63b1b2bd060fb9":{"type":"string","example":"Fluorescent","can_have_multiple_values":false,"fieldname":"LightBulbType","key":"light_bulb_type","recommended":false,"description":"The type of light bulb."},"0e8054ce0f52ba0d4105f9da4cbfcbfe":{"type":"measurement","example":"12 oz","enum_values":["ml","l","oz","cu_ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"Capacity","key":"capacity","recommended":false,"description":"Indicates the maximum amount that the item can hold like pounds, liters or volume. Does not include Storage Capacity which is used for digital items."},"64b3fe664fa4c3666faae8b77a734631":{"type":"measurement","example":"12 oz","enum_values":["ml","l","oz","cu_ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"Capacity","key":"capacity","recommended":true,"description":"Indicates the maximum amount that the item can hold like pounds, liters or volume. Does not include Storage Capacity which is used for digital items."},"7c421b8f435ae90ca36f71389bd6b9ca":{"type":"measurement","example":"10 g","enum_values":["mg","g","kg","oz","lb"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"ProductWeight","key":"product_weight","recommended":true,"description":"The weight of the fully assembled product."},"3eb15df7a5722992f9aa3dbf1a8c3923":{"type":"string","example":["Low Noise"],"can_have_multiple_values":true,"fieldname":"AdditionalFeatures","key":"additional_features","recommended":false,"description":"Additional features related to your item that might be important for buyers."},"049be88f7223ae9a349f4d47ec511389":{"type":"measurement","example":"220 V","enum_values":["V","KV"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"Volts","key":"volts","recommended":false,"description":"The number of volts the product produces or requires. Also known as Voltage;"},"3aa26481e6a2737040dacf5844ff32f2":{"type":"enum","example":["Automatic Shut Off"],"can_have_multiple_values":true,"enum_values":["Automatic Shut Off","Energy Star-Certified","Bluetooth Compatible","Industrial","Remote Control Included","Wi-Fi Compatible"],"can_have_unknown_value":false,"fieldname":"StandardFeatures","key":"standard_features","recommended":false,"description":"Standard features related to your item that might be important for buyers."},"1b4aabae8670a6b5f8ad83a12c664b37":{"type":"string","example":44,"can_have_multiple_values":false,"fieldname":"SoundRating","key":"sound_rating","recommended":false,"description":"The sound decibel rating for the noise level of the appliance."},"43e44c783f17bdfc8772466174badee1":{"type":"string","example":["Amazon Alexa"],"can_have_multiple_values":true,"fieldname":"SmartHomeCompatibility","key":"smart_home_compatibility","recommended":false,"description":"The type of Smart Home devices that the product is compatible with."},"140a15b94c6d50aa103b176dc71951ff":{"type":"integer","example":2,"can_have_multiple_values":false,"fieldname":"NumberofDoors","key":"numberof_doors","recommended":false,"description":"The number of doors on the item."},"454fe2a0cbc9e12c03b9db3ccfe98a21":{"type":"integer","example":4,"can_have_multiple_values":false,"fieldname":"NumberofBurners","key":"numberof_burners","recommended":false,"description":"The number of cooking burners or elements."},"b771092e645e5a68eb3c34f590d4a028":{"type":"string","example":"Top Load","can_have_multiple_values":false,"fieldname":"LoadPosition","key":"load_position","recommended":false,"description":"The type of load position for washers & dryers."},"da1ff3922c1b46224c541ecf62c91f69":{"type":"boolean","example":"yes","can_have_multiple_values":false,"can_have_unknown_value":false,"enum_values":["yes","no"],"fieldname":"IsSet","key":"is_set","recommended":false,"description":"Indicates if the product is being sold as a set, like washer & dryer set."},"424a3c305eb21ffbd1257294397cc022":{"type":"string","example":"Electric","can_have_multiple_values":false,"fieldname":"FuelType","key":"fuel_type","recommended":false,"description":"The type of fuel used to power certain appliances."},"96481ec4bdef8e6fe8e5093ef39a68d0":{"type":"integer","example":10200,"can_have_multiple_values":false,"fieldname":"BTU","key":"b_t_u","recommended":false,"description":"The number of British Thermal Units for heating and cooling appliances."},"608d8c80b0c29120dd74b33b92b656f3":{"type":"measurement","example":"400 W","enum_values":["W","KW","MW","GW"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"Watts","key":"watts","recommended":false,"description":"The number of watts the product procues or requires. Also known as Wattage."},"8f4a7d7221541f65cac8a79c08758bfb":{"type":"string","example":"Oil","can_have_multiple_values":false,"fieldname":"ProductForm","key":"product_form","recommended":true,"description":"The consistency, texture or formulation of the item and the way\n          it will be consumed or dispensed."},"803d2a584a08f5944b306958fdb95a21":{"type":"string","example":["Vanilla"],"can_have_multiple_values":true,"fieldname":"Scent","key":"scent","recommended":true,"description":"The scent or fragrance of your item; including items\n        labelled as \"unscented\""},"4e7d7d90f4137c48ce55a4b9a823eff2":{"type":"string","example":["some_string","other"],"can_have_multiple_values":true,"fieldname":"Ingredients","key":"ingredients","recommended":true,"description":"The list of all ingredients contained in an item, as found on the product label mandated by FDA guidelines."},"c8d76e2396b1577c1c9da0d9ec4cf770":{"type":"string","example":["Carpet"],"can_have_multiple_values":true,"fieldname":"RecommendedUse","key":"recommended_use","recommended":true,"description":"The recommended use\/surface of cleaning product."},"ec65783a5d3d73c90f83a5d59797ac73":{"type":"string","example":["Unscented"],"can_have_multiple_values":true,"fieldname":"AdditionalFeatures","key":"additional_features","recommended":false,"description":"Additional features related to your item that might be important for buyers."},"febfed4ca6efd5a645a1862390468384":{"type":"string","example":"Canister","can_have_multiple_values":false,"fieldname":"VacuumType","key":"vacuum_type","recommended":false,"description":"The type of vacuum cleaner."},"da6b491d82e229483b578dec94e4ff95":{"type":"enum","example":["Biodegradable"],"can_have_multiple_values":true,"enum_values":["Biodegradable","Recyclable"],"can_have_unknown_value":false,"fieldname":"StandardFeatures","key":"standard_features","recommended":false,"description":"Standard features related to your item that might be important for buyers."},"6cc94d5bc1810a51cf9b3139b629fd37":{"type":"integer","example":15,"can_have_multiple_values":false,"fieldname":"ShelfLife","key":"shelf_life","recommended":false,"description":"The length of time that the product can be stored without spoiling or losing quality, measured in days."},"23a063f0e0a0a294b129169b749639fa":{"type":"measurement","example":"12 oz","enum_values":["ml","l","oz","cu_ft"],"can_have_multiple_values":false,"can_have_unknown_value":false,"fieldname":"Capacity","key":"capacity","recommended":false,"description":"Indicates the maximum amount that the item can hold like pounds, liters or volume."},"b9bee7f2bace5f8065911d6998b34bad":{"type":"string","example":"Bag","can_have_multiple_values":false,"fieldname":"BagType","key":"bag_type","recommended":false,"description":"Indicates whether the vacuum cleaner is bag or bagless."},"07360c7815892f05de28ec9f92926612":{"type":"enum","example":["Chemical"],"can_have_multiple_values":true,"enum_values":["Chemical","Combustible","Flammable"],"can_have_unknown_value":false,"fieldname":"Warnings","key":"warnings","recommended":false,"description":"Warnings associated with the product."},"e6c000a4a5c024e4385c9e89ef1232c3":{"type":"integer","example":400,"can_have_multiple_values":false,"fieldname":"ThreadCount","key":"thread_count","recommended":true,"description":"The number of threads per square inch of fabric."},"2410d57d61f0e552896d9aca00f7b67b":{"type":"enum","example":["Water Resistant"],"can_have_multiple_values":true,"enum_values":["Reversible","Hypoallergenic","Stain Resistant","Water Resistant","Organic","Sustainably Sourced"],"can_have_unknown_value":false,"fieldname":"StandardFeatures","key":"standard_features","recommended":false,"description":"Standard features related to your item that might be important for buyers."},"c1a740062d17b6704080705c2474435c":{"type":"integer","example":3,"can_have_multiple_values":false,"fieldname":"PiecesInSet","key":"pieces_in_set","recommended":false,"description":"The number of items included in the set. If the item contains matching fitted sheets, flat sheets, and 2 pillowcases - the number is 4."},"0f4c1a53965b293c894d4b0e607b9770":{"type":"string","example":["Designer","Anti-Streak"],"can_have_multiple_values":true,"fieldname":"AdditionalFeatures","key":"additional_features","recommended":false,"description":"Additional features related to your item that might be important for buyers."},"4a6f34f51dbacff4a7033c14e600ce06":{"type":"boolean","example":"yes","can_have_multiple_values":false,"can_have_unknown_value":false,"enum_values":["yes","no"],"fieldname":"IsSet","key":"is_set","recommended":false,"description":"Indicates if the product contains 2 of more different items that are sold as part of a set."},"e8e50abdc6b50b497e7c90af199feeec":{"type":"integer","example":1,"can_have_multiple_values":false,"fieldname":"NumberOfLicenses","key":"number_of_licenses","recommended":true,"description":"The maximum number of users or installations allowed under the terms of the software licensing agreement."},"9c3c05234da77307c8b4fc50977ca324":{"type":"string","example":["Windows 7 or later"],"can_have_multiple_values":true,"fieldname":"SoftwareSystemRequirements","key":"software_system_requirements","recommended":true,"description":"The basic requirements necessary of any system in order to satisfactorily run the software."},"46c833eff8474794a70b21f9d2389e04":{"type":"string","example":"Antivirus & Security","can_have_multiple_values":false,"fieldname":"SoftwareCategory","key":"software_category","recommended":false,"description":"The general category of software to which the item is most closely associated with"},"1c4ef2904cadfca2cf53773ad85ce53d":{"type":"string","example":"7.2","can_have_multiple_values":false,"fieldname":"SoftwareVersion","key":"software_version","recommended":false,"description":"The version number assigned to this specific release of the software."}}
+{
+    "5773e3cf8b57a590831b2fa4966071b7": {
+      "key": "gender",
+      "fieldname": "Gender",
+      "recommended": false,
+      "type": "enum",
+      "description": "Gender the product item is targeted towards",
+      "enum_values": ["female", "male", "unisex"],
+      "can_have_unknown_value": false
+    },
+    "e44fa2f9d73d8394fc19e11bda594270": {
+      "key": "color",
+      "fieldname": "Color",
+      "recommended": false,
+      "type": "string",
+      "description": "Color of the product item"
+    },
+    "3c93dcbe5e2427633884455f8fdf3d0a": {
+      "key": "size",
+      "fieldname": "size",
+      "recommended": false,
+      "type": "string",
+      "description": "Size of the product item"
+    },
+    "14360682ab38bda0c27cd410da1ddb93": {
+      "key": "pattern",
+      "fieldname": "Pattern",
+      "recommended": false,
+      "type": "string",
+      "description": "Pattern of the product item"
+    },
+    "57a5027e44183e4bee60fd79e0f72215": {
+      "key": "material",
+      "fieldname": "Material",
+      "recommended": false,
+      "type": "string",
+      "description": "Material of the product item"
+    },
+    "536559919dfbf7c806f82836c7b6ace0": {
+      "key": "age_group",
+      "fieldname": "AgeGroup",
+      "recommended": false,
+      "type": "enum",
+      "description": "Age group the product item is targeted towards",
+      "enum_values": [
+        "adult",
+        "all ages",
+        "infant",
+        "kids",
+        "newborn",
+        "teen",
+        "toddler"
+      ],
+      "can_have_unknown_value": false
+    },
+    "fdbb66325f7179c53e0d013f85a8f1bb": {
+      "key": "material",
+      "fieldname": "Material",
+      "recommended": true,
+      "type": "string",
+      "description": "Material of the product item"
+    },
+    "56beea7a921d2d0a4b65bcb91de4619f": {
+      "type": "measurement",
+      "example": "10 g",
+      "enum_values": ["mg", "g", "kg", "oz", "lb"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "MinimumWeight",
+      "key": "minimum_weight",
+      "recommended": true,
+      "description": "The lower weight limit or capability of an item,often used in conjunction with \"Maximum Weight\".The meaning varies with context of product.For example, when used with \"Maximum Weight\",this attribute provides weight ranges for a range of productsincluding pet medicine, baby carriers and outdoor play structures."
+    },
+    "b4e2ba079a90aafe22d7b40a27a8a86b": {
+      "type": "string",
+      "example": "1-3 Years",
+      "can_have_multiple_values": false,
+      "fieldname": "AgeRange",
+      "key": "age_range",
+      "recommended": true,
+      "description": "Minimum and Maximum Ages for a product. Note: the unit of measure in\n        Months, or Years."
+    },
+    "d86e410dc0b595fa52c8071297df164e": {
+      "type": "measurement",
+      "example": "10 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "ProductWidth",
+      "key": "product_width",
+      "recommended": true,
+      "description": "The width of the fully assembled product."
+    },
+    "fb29eb2f1bed6b57202be5766b13a012": {
+      "key": "color",
+      "fieldname": "Color",
+      "recommended": true,
+      "type": "string",
+      "description": "Color of the product item"
+    },
+    "6f6763dc75294a1700c3325ed0e01501": {
+      "type": "measurement",
+      "example": "10 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "ProductLength",
+      "key": "product_length",
+      "recommended": true,
+      "description": "The length of the fully assembled product."
+    },
+    "a125082f8b596fd6a3fc4ef69aac4ce9": {
+      "key": "gender",
+      "fieldname": "Gender",
+      "recommended": true,
+      "type": "enum",
+      "description": "Gender the product item is targeted towards",
+      "enum_values": ["female", "male", "unisex"],
+      "can_have_unknown_value": false
+    },
+    "b77f4835261839838cf7da93a4397624": {
+      "type": "measurement",
+      "example": "10 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "ProductHeight",
+      "key": "product_height",
+      "recommended": true,
+      "description": "The height of the fully assembled product"
+    },
+    "fab78b5f78ea9c6822f0efd4b76812c7": {
+      "type": "measurement",
+      "example": "10 g",
+      "enum_values": ["mg", "g", "kg", "oz", "lb"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "MaximumWeight",
+      "key": "maximum_weight",
+      "recommended": true,
+      "description": "The upper weight limit or capability of an item,often used in conjunction with \"Minimum Weight\".The meaning varies with context of product.For example, when used with \"Minimum Weight\",this attribute provides weight ranges for a range of productsincluding pet medicine, baby carriers and outdoor play structures."
+    },
+    "c33d8f504a0d16cc768948032b96bb86": {
+      "type": "string",
+      "example": ["Waterproof"],
+      "can_have_multiple_values": true,
+      "fieldname": "AdditionalFeatures",
+      "key": "additional_features",
+      "recommended": false,
+      "description": "Additional features related to your item that might be important for buyers."
+    },
+    "75d33e09027a3e497cd7f4871c44d0ad": {
+      "type": "string",
+      "example": "Shape Identification",
+      "can_have_multiple_values": false,
+      "fieldname": "EducationalFocus",
+      "key": "educational_focus",
+      "recommended": false,
+      "description": "Describes the educational skills that the product is intended to improve"
+    },
+    "a61b31aad2b1cff7a5e059435aa0c079": {
+      "type": "string",
+      "example": "Chewbacca",
+      "can_have_multiple_values": false,
+      "fieldname": "Character",
+      "key": "character",
+      "recommended": false,
+      "description": "The particular character, person or entity that your item represents or is associated with."
+    },
+    "186773615b385aea09f78bf7846c2da2": {
+      "type": "string",
+      "example": "Space",
+      "can_have_multiple_values": false,
+      "fieldname": "Theme",
+      "key": "theme",
+      "recommended": false,
+      "description": "The particular subject, theme or idea that your item represents or is associated with."
+    },
+    "f0cc9df58632d42a9f64e187e36822ac": {
+      "type": "boolean",
+      "example": "yes",
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "enum_values": ["yes", "no"],
+      "fieldname": "IsAssemblyRequired",
+      "key": "is_assembly_required",
+      "recommended": true,
+      "description": "Indicates if the product arrives unassembledand must be put together before use."
+    },
+    "18213b9375e78464379a596bc5a12105": {
+      "type": "string",
+      "example": "jogging",
+      "can_have_multiple_values": false,
+      "fieldname": "StrollerType",
+      "key": "stroller_type",
+      "recommended": false,
+      "description": "Prominent stroller styles."
+    },
+    "e294d165c14bf93d4ff9d565c45b86f0": {
+      "type": "enum",
+      "example": ["Foldable"],
+      "can_have_multiple_values": true,
+      "enum_values": ["Foldable"],
+      "can_have_unknown_value": false,
+      "fieldname": "StandardFeatures",
+      "key": "standard_features",
+      "recommended": false,
+      "description": "Standard features related to your item that might be important for buyers."
+    },
+    "09e6b8670b86e122237dee1d1948f5e3": {
+      "type": "string",
+      "example": "3-point harness",
+      "can_have_multiple_values": false,
+      "fieldname": "SafetyHarnessStyle",
+      "key": "safety_harness_style",
+      "recommended": false,
+      "description": "The style of the occupant restraint harness included with the car\n          seat, stroller, carrier, etc."
+    },
+    "5a781cf5acf5b20a3457889ab0719688": {
+      "type": "integer",
+      "example": 1,
+      "can_have_multiple_values": false,
+      "fieldname": "NumberOfSeats",
+      "key": "number_of_seats",
+      "recommended": false,
+      "description": "The number of people that can be accommodated by the\n        available seats of an item."
+    },
+    "acb1aef05b9c5b358e8d767422053a0c": {
+      "type": "string",
+      "example": "Convertible Car Seats",
+      "can_have_multiple_values": false,
+      "fieldname": "ChildCarSeatStyle",
+      "key": "child_car_seat_style",
+      "recommended": false,
+      "description": "Prominent car seat styles."
+    },
+    "84520363ef89687443e2b75aac0ca2a4": {
+      "type": "string",
+      "example": "3 ft",
+      "can_have_multiple_values": false,
+      "fieldname": "CarSeatMaxChildHeight",
+      "key": "car_seat_max_child_height",
+      "recommended": false,
+      "description": "The maximum height of the child occupant as given by the\n          manufacturer, measured in inches or centimeters."
+    },
+    "9d014a512c1e3019550901b0c0494ff4": {
+      "type": "string",
+      "example": "Forward-Facing",
+      "can_have_multiple_values": false,
+      "fieldname": "CarSeatFacingDirection",
+      "key": "car_seat_facing_direction",
+      "recommended": false,
+      "description": "Which direction the car seat faces."
+    },
+    "c139a1077e40bc1ed55105d8250cfbd7": {
+      "type": "string",
+      "example": "sling",
+      "can_have_multiple_values": false,
+      "fieldname": "BabyCarrierStyle",
+      "key": "baby_carrier_style",
+      "recommended": false,
+      "description": "Prominent wearable baby carrier styles."
+    },
+    "de2ea24937f3cfb9d23a6184b6bb1717": {
+      "type": "string",
+      "example": "front carry-facing in",
+      "can_have_multiple_values": false,
+      "fieldname": "BabyCarrierPosition",
+      "key": "baby_carrier_position",
+      "recommended": false,
+      "description": "Applies to wearable baby carriers. Describes the part of the body\n          against which the child is placed along with the direction the child\n          faces (where applicable) while in the wearable baby carrier."
+    },
+    "3e6c4c356607b43e111bc414a797367c": {
+      "type": "integer",
+      "example": 12,
+      "can_have_multiple_values": false,
+      "fieldname": "PackageQuantity",
+      "key": "package_quantity",
+      "recommended": true,
+      "description": "The total number of items included in the package or box."
+    },
+    "b2e91b6002cde2bfa85933056e1fbab1": {
+      "key": "size",
+      "fieldname": "size",
+      "recommended": true,
+      "type": "string",
+      "description": "Size of the product item"
+    },
+    "e84c396def9cf6dfa460ad427e4086f1": {
+      "type": "string",
+      "example": ["Stop using if you experience swelling, rash, or fever"],
+      "can_have_multiple_values": true,
+      "fieldname": "StopUseIndications",
+      "key": "stop_use_indications",
+      "recommended": false,
+      "description": "Information that describes symptoms or reactions that\n        indicate when to stop using the product."
+    },
+    "f9f15a8a99459328f839fb1423283f15": {
+      "type": "string",
+      "example": ["Vanilla"],
+      "can_have_multiple_values": true,
+      "fieldname": "Scent",
+      "key": "scent",
+      "recommended": false,
+      "description": "The scent or fragrance of your item; including items\n        labelled as \"unscented\""
+    },
+    "ad4e681a4cf1c32d992b0119533bb4f3": {
+      "type": "string",
+      "example": "Oil",
+      "can_have_multiple_values": false,
+      "fieldname": "ProductForm",
+      "key": "product_form",
+      "recommended": false,
+      "description": "The consistency, texture or formulation of the item and the way\n          it will be consumed or dispensed."
+    },
+    "4ddda60fca4317fa3a260bc6a716eacb": {
+      "type": "measurement",
+      "example": "10 g",
+      "enum_values": ["mg", "g", "kg", "oz", "lb"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "MaximumWeight",
+      "key": "maximum_weight",
+      "recommended": false,
+      "description": "The upper weight limit or capability of an item,often used in conjunction with \"Minimum Weight\".The meaning varies with context of product.For example, when used with \"Minimum Weight\",this attribute provides weight ranges for a range of productsincluding pet medicine, baby carriers and outdoor play structures."
+    },
+    "9bf1fceb6bbc26681a6531a069d97089": {
+      "type": "measurement",
+      "example": "10 g",
+      "enum_values": ["mg", "g", "kg", "oz", "lb"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "MinimumWeight",
+      "key": "minimum_weight",
+      "recommended": false,
+      "description": "The lower weight limit or capability of an item,often used in conjunction with \"Maximum Weight\".The meaning varies with context of product.For example, when used with \"Maximum Weight\",this attribute provides weight ranges for a range of productsincluding pet medicine, baby carriers and outdoor play structures."
+    },
+    "1b2a0250577aa3367755a9d309396596": {
+      "type": "string",
+      "example": ["Apply to wet hair", "Massage into scalp", "Rinse thoroughly"],
+      "can_have_multiple_values": true,
+      "fieldname": "Instructions",
+      "key": "instructions",
+      "recommended": false,
+      "description": "Detailed information telling how the product should be operated,\n           assembled, or consumed."
+    },
+    "cb857165d244dc15e39ea8f1e8752ee8": {
+      "type": "string",
+      "example": ["some_string", "other"],
+      "can_have_multiple_values": true,
+      "fieldname": "Ingredients",
+      "key": "ingredients",
+      "recommended": false,
+      "description": "The list of all ingredients contained in an item, as found on the product label mandated by FDA guidelines."
+    },
+    "06824c1d350fd02b20f1ccb63dc70aa2": {
+      "type": "string",
+      "example": "Cloth",
+      "can_have_multiple_values": false,
+      "fieldname": "DiaperType",
+      "key": "diaper_type",
+      "recommended": false,
+      "description": "Describes the type of diaper"
+    },
+    "fdb673fe23dcfd4e913ea68db30f1886": {
+      "type": "enum",
+      "example": "Infant",
+      "can_have_multiple_values": false,
+      "enum_values": ["Newborn", "Infant", "Toddler"],
+      "can_have_unknown_value": false,
+      "fieldname": "BabyLifeStage",
+      "key": "baby_life_stage",
+      "recommended": false,
+      "description": "Describes the life stage of the child"
+    },
+    "4a1709fc558601d050f61caacf1886f7": {
+      "type": "string",
+      "example": "Stage 1",
+      "can_have_multiple_values": false,
+      "fieldname": "BabyFoodStage",
+      "key": "baby_food_stage",
+      "recommended": true,
+      "description": "Attribute designed to capture the generalized age grouping (commonly referred to as \"stage\") of a given baby food, as specified by manufacturer. Example descriptions: Stage 1 -  Foods have a single ingredient and are pureed and generally contain about 2.5 oz  of fruits, veggies or meats. Stage 2  -  Foods are strained instead of pureed and have a combination of fruits or veggies instead of single ingredients, contain larger portions. Stage 3  -  Foods are mashed and have more texture than the pureed foods and may have bits and chunks of meats or veggies."
+    },
+    "b5ab18b31d909d41c1dc88e00bac6e44": {
+      "type": "measurement",
+      "example": "10 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "ProductWidth",
+      "key": "product_width",
+      "recommended": false,
+      "description": "The width of the fully assembled product."
+    },
+    "812cdd6be6bd77d8fae155eee4b5ca8e": {
+      "type": "measurement",
+      "example": "10 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "ProductLength",
+      "key": "product_length",
+      "recommended": false,
+      "description": "The length of the fully assembled product."
+    },
+    "045b717bb79c0b39f9d17afd53120c44": {
+      "type": "measurement",
+      "example": "10 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "ProductHeight",
+      "key": "product_height",
+      "recommended": false,
+      "description": "The height of the fully assembled product"
+    },
+    "666634cdd39d094fdf806ea000651fd9": {
+      "type": "integer",
+      "example": 12,
+      "can_have_multiple_values": false,
+      "fieldname": "PackageQuantity",
+      "key": "package_quantity",
+      "recommended": false,
+      "description": "The total number of items included in the package or box."
+    },
+    "1f60a7e1c843194aef22644bdc923372": {
+      "type": "string",
+      "example": ["Yams"],
+      "can_have_multiple_values": true,
+      "fieldname": "Ingredients",
+      "key": "ingredients",
+      "recommended": false,
+      "description": "The list of all ingredients contained in an item, as found on the product label mandated by FDA guidelines."
+    },
+    "0412c658ae5558750f3d8dcf73b35e2f": {
+      "type": "string",
+      "example": ["Cinnamon", "Peppermint"],
+      "can_have_multiple_values": true,
+      "fieldname": "Flavor",
+      "key": "flavor",
+      "recommended": false,
+      "description": "Describes the taste or flavor of the item, as described by the\n          manufacturer. May be an important attribute for shoppers for items\n          like dental products, medicine or baby foods."
+    },
+    "003aaedcb75e3bdf52a4a7c043bc83bf": {
+      "type": "string",
+      "example": "Contains Peanuts",
+      "can_have_multiple_values": false,
+      "fieldname": "Allergens",
+      "key": "allergens",
+      "recommended": false,
+      "description": "Statement regarding any ingredients that may be food allergens, often written as \"Contains X\" or \"Manufactured in a facility which processes Y.\""
+    },
+    "f29ece641eb9d606c99f8ff1375cdafd": {
+      "type": "string",
+      "example": 16,
+      "can_have_multiple_values": false,
+      "fieldname": "Megapixels",
+      "key": "megapixels",
+      "recommended": true,
+      "description": "Describes the resolution at which this item records images."
+    },
+    "198abe5c383734cf1f5c25725ad05626": {
+      "type": "string",
+      "example": 6,
+      "can_have_multiple_values": false,
+      "fieldname": "DigitalZoom",
+      "key": "digital_zoom",
+      "recommended": true,
+      "description": "Describes the magnification power provided by a feature that electronically enlarges the image area"
+    },
+    "3c84275e3f255e24439d4d2acca1738c": {
+      "type": "string",
+      "example": 10,
+      "can_have_multiple_values": false,
+      "fieldname": "OpticalZoom",
+      "key": "optical_zoom",
+      "recommended": true,
+      "description": "Describes the magnification power of a physical optical zoom lens."
+    },
+    "5546fa0a68017a13c3d54f434b16e543": {
+      "type": "string",
+      "example": "Lenovo Thinkpad",
+      "can_have_multiple_values": false,
+      "fieldname": "Model",
+      "key": "model",
+      "recommended": true,
+      "description": "The common name of the model of the product. Does not include model numbers."
+    },
+    "c73360481bac2974a2647239ba9ac090": {
+      "type": "string",
+      "example": "USB 2.0",
+      "can_have_multiple_values": false,
+      "fieldname": "USBTechnology",
+      "key": "u_s_b_technology",
+      "recommended": false,
+      "description": "Describes the version of USB technology on the product."
+    },
+    "fb5d85a3717fff61798f843282121fc6": {
+      "type": "enum",
+      "example": ["Flash"],
+      "can_have_multiple_values": true,
+      "enum_values": [
+        "35mm Jack",
+        "Downloadable Content",
+        "Online Multiplayer",
+        "Touchscreen",
+        "Bluetooth",
+        "GPS",
+        "SIM",
+        "USB Connectivity",
+        "WLAN",
+        "Portable",
+        "Unlocked",
+        "Auto Document Feeder",
+        "Auto Two-Sided Printing",
+        "Energy Star Certified",
+        "Integrated Speakers",
+        "3D",
+        "Smart",
+        "Flash",
+        "Microphone",
+        "Red Eye Reduction"
+      ],
+      "can_have_unknown_value": false,
+      "fieldname": "StandardFeatures",
+      "key": "standard_features",
+      "recommended": false,
+      "description": "Standard features related to your item that might be important for buyers."
+    },
+    "e52c7222866dfa79fb54fb46377f2dba": {
+      "type": "string",
+      "example": "USB-C",
+      "can_have_multiple_values": false,
+      "fieldname": "USBType",
+      "key": "u_s_b_type",
+      "recommended": false,
+      "description": "Describes the type of USB connector on the product."
+    },
+    "a557ee533a27f6ba2ab2896f50128d2b": {
+      "type": "string",
+      "example": ["Portrait"],
+      "can_have_multiple_values": true,
+      "fieldname": "ShootingModes",
+      "key": "shooting_modes",
+      "recommended": false,
+      "description": "Describes the available settings designed to accommodate different photographic situations."
+    },
+    "cb76a2503550b23c7e96374acff9974c": {
+      "type": "string",
+      "example": 250,
+      "can_have_multiple_values": false,
+      "fieldname": "MinimumShutterSpeed",
+      "key": "minimum_shutter_speed",
+      "recommended": false,
+      "description": "Describes the minimum shutter speed of the item. Measured in seconds."
+    },
+    "dfa8888400db20a0c59123675195f680": {
+      "type": "string",
+      "example": 2,
+      "can_have_multiple_values": false,
+      "fieldname": "SelfTimerDelay",
+      "key": "self_timer_delay",
+      "recommended": false,
+      "description": "Length of time in seconds the self-timer will allow before it\n          takes a photo"
+    },
+    "80a2c75641a182aabe897e4d0c5c8ea2": {
+      "type": "measurement",
+      "example": "42 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "ScreenSize",
+      "key": "screen_size",
+      "recommended": false,
+      "description": "Describes the measurement of the device's screen, typically measured diagonally in inches."
+    },
+    "4b71478ae3751b69220f8f35f0f65ab9": {
+      "type": "string",
+      "example": "1/2.3 in",
+      "can_have_multiple_values": false,
+      "fieldname": "SensorResolution",
+      "key": "sensor_resolution",
+      "recommended": false,
+      "description": "One specification describing the smallest detectable incremental change of input parameter that can be detected in the output signal. For digital cameras, image sensor resolution is an important factor for image quality."
+    },
+    "82aef4349fbc23a369243c604b574e3a": {
+      "type": "string",
+      "example": "f/16",
+      "can_have_multiple_values": false,
+      "fieldname": "MinimumAperture",
+      "key": "minimum_aperture",
+      "recommended": false,
+      "description": "The smallest aperture this item accommodates; typically expressed in f-numbers."
+    },
+    "73d65ceca095eeba210477fa2c3566ca": {
+      "type": "string",
+      "example": "f/5",
+      "can_have_multiple_values": false,
+      "fieldname": "FocalRatio",
+      "key": "focal_ratio",
+      "recommended": false,
+      "description": "Ratio of the lens's focal length, to the diameter of the entrance pupil. Also known as the f-number or f-stop, this number indicates lens speed."
+    },
+    "7518e31e367a461a82c93d537dc2c7da": {
+      "type": "string",
+      "example": ["iPad"],
+      "can_have_multiple_values": true,
+      "fieldname": "CompatibleDevices",
+      "key": "compatible_devices",
+      "recommended": false,
+      "description": "Devices compatible with the item."
+    },
+    "ba6bb30e5d011b3182c2d01d3ec52356": {
+      "type": "string",
+      "example": "HDMI",
+      "can_have_multiple_values": false,
+      "fieldname": "ConnectorType",
+      "key": "connector_type",
+      "recommended": false,
+      "description": "Describes the types of connections supported on the item."
+    },
+    "aaa86538e1892f9637b83693ea86da06": {
+      "type": "string",
+      "example": "LCD",
+      "can_have_multiple_values": false,
+      "fieldname": "DisplayTechnology",
+      "key": "display_technology",
+      "recommended": false,
+      "description": "Describes the type of technology that powers the display, like LED or LCD."
+    },
+    "3f3305be9612e01d2d0b854c2e23dd0f": {
+      "type": "string",
+      "example": "Built-in Camera",
+      "can_have_multiple_values": false,
+      "fieldname": "FlashType",
+      "key": "flash_type",
+      "recommended": false,
+      "description": "The type of flash the camera has or can accommodate."
+    },
+    "27ac044687275eca92c8ffc695dfcfac": {
+      "type": "string",
+      "example": 18,
+      "can_have_multiple_values": false,
+      "fieldname": "FocalLength",
+      "key": "focal_length",
+      "recommended": false,
+      "description": "On a camera or lens, the distance between the image sensor and the lens when the subject is in focus,stated as a range in millimeters."
+    },
+    "b5dd74005f37c4313d88aaf9ec09a6ce": {
+      "type": "measurement",
+      "example": "10 h",
+      "enum_values": ["s", "m", "h", "d"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "BatteryLife",
+      "key": "battery_life",
+      "recommended": false,
+      "description": "Describes the total battery life (or maximum run time) of the item, typically measured in hours."
+    },
+    "25dd344c790ce67c74887cef8bf51bf9": {
+      "type": "string",
+      "example": ["Scratch-Resistant"],
+      "can_have_multiple_values": true,
+      "fieldname": "LensCoating",
+      "key": "lens_coating",
+      "recommended": false,
+      "description": "Type of thin layer of material applied to the surface of lenses or other optical elements that provide specific effects."
+    },
+    "37ced536fc643daf19b3e78c6109d462": {
+      "type": "string",
+      "example": 49,
+      "can_have_multiple_values": false,
+      "fieldname": "LensDiameter",
+      "key": "lens_diameter",
+      "recommended": false,
+      "description": "Measurement of the diameter of the front portion of the lens, measured in mm."
+    },
+    "fa1806a7580ccac912c41dc13a38f9f2": {
+      "type": "string",
+      "example": "Cooling",
+      "can_have_multiple_values": false,
+      "fieldname": "LensFilter",
+      "key": "lens_filter",
+      "recommended": false,
+      "description": "Describes the kind of filter attached to a lens."
+    },
+    "ee8a6aaa75b14a3f55320e0ff3bf4e19": {
+      "type": "string",
+      "example": "f/1.4",
+      "can_have_multiple_values": false,
+      "fieldname": "MaximumAperture",
+      "key": "maximum_aperture",
+      "recommended": false,
+      "description": "Size of the largest aperture this item accommodates; typically expressed in f-numbers."
+    },
+    "2693162e8e03185c2f7147c2ed198794": {
+      "type": "string",
+      "example": 0.00025,
+      "can_have_multiple_values": false,
+      "fieldname": "MaximumShutterSpeed",
+      "key": "maximum_shutter_speed",
+      "recommended": false,
+      "description": "Describes the maximum shutter speed of the item. Measured in seconds."
+    },
+    "2af16c00b68ea710c43881873f0c0eab": {
+      "type": "string",
+      "example": ["WiFi"],
+      "can_have_multiple_values": true,
+      "fieldname": "WirelessTechnologies",
+      "key": "wireless_technologies",
+      "recommended": false,
+      "description": "Describes the types of wireless technologies that can be used by the product."
+    },
+    "1d70a2d3ce76a127d1ffb1b2f4209ac9": {
+      "key": "age_group",
+      "fieldname": "AgeGroup",
+      "recommended": true,
+      "type": "enum",
+      "description": "Age group the product item is targeted towards",
+      "enum_values": [
+        "adult",
+        "all ages",
+        "infant",
+        "kids",
+        "newborn",
+        "teen",
+        "toddler"
+      ],
+      "can_have_unknown_value": false
+    },
+    "6d21b5b1295293a171d1c7d989e9db81": {
+      "type": "string",
+      "example": ["Bodycon"],
+      "can_have_multiple_values": true,
+      "fieldname": "Style",
+      "key": "style",
+      "recommended": true,
+      "description": "The style(s) associated with the item."
+    },
+    "df971d2b5138c017068b1b1ca5fe7ff0": {
+      "key": "pattern",
+      "fieldname": "Pattern",
+      "recommended": true,
+      "type": "string",
+      "description": "Pattern of the product item"
+    },
+    "7992ac8898667c0ac4a874e914c71ec0": {
+      "type": "string",
+      "example": ["Designer", "Embroidered"],
+      "can_have_multiple_values": true,
+      "fieldname": "AdditionalFeatures",
+      "key": "additional_features",
+      "recommended": false,
+      "description": "Additional features related to your item that might be important for buyers."
+    },
+    "03321e77f42ca941c319d9d3a696e822": {
+      "type": "string",
+      "example": "Flutter",
+      "can_have_multiple_values": false,
+      "fieldname": "SleeveStyle",
+      "key": "sleeve_style",
+      "recommended": false,
+      "description": "The style of sleeves. Does not include sleeve length styles."
+    },
+    "ef7cf809c0d3f3dde722b692949e8a82": {
+      "type": "enum",
+      "example": "US",
+      "can_have_multiple_values": false,
+      "enum_values": [
+        "US",
+        "UK",
+        "EU",
+        "DE",
+        "FR",
+        "JP",
+        "CN",
+        "IT",
+        "BR",
+        "MEX",
+        "AU"
+      ],
+      "can_have_unknown_value": true,
+      "fieldname": "SizeSystem",
+      "key": "size_system",
+      "recommended": false,
+      "description": "The size system used by your item, usually corresponds to Country."
+    },
+    "891fd9d63794da9979642269ffdf2bdb": {
+      "type": "measurement",
+      "example": "32 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "SkirtLength",
+      "key": "skirt_length",
+      "recommended": false,
+      "description": "The numeric length value of shirt sleeves. Does not include styles of shirt sleeves like 3/4 Sleeve."
+    },
+    "d0074b6e5f6d004d8b24dee11da5c838": {
+      "type": "measurement",
+      "example": "32 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "SleeveLength",
+      "key": "sleeve_length",
+      "recommended": false,
+      "description": "The numeric length value of skirts from waist to bottom. Does not include style values like Maxi."
+    },
+    "c49d53b2f6e3b840d1b3b36cf763b823": {
+      "type": "enum",
+      "example": "3/4 Sleeve",
+      "can_have_multiple_values": false,
+      "enum_values": ["3/4 Sleeve", "Long Sleeve", "Short Sleeve", "Sleeveless"],
+      "can_have_unknown_value": true,
+      "fieldname": "SleeveLengthStyle",
+      "key": "sleeve_length_style",
+      "recommended": false,
+      "description": "The style of sleeve length. Does not include sleeve styles."
+    },
+    "ebc88b022a77d94e80822b572e926b7a": {
+      "type": "string",
+      "example": ["Tennis"],
+      "can_have_multiple_values": true,
+      "fieldname": "Sport",
+      "key": "sport",
+      "recommended": false,
+      "description": "The particular sport or activity for which your item is intended."
+    },
+    "5db117ce3ae7225ccccb737276630902": {
+      "type": "enum",
+      "example": "Ankle",
+      "can_have_multiple_values": false,
+      "enum_values": [
+        "Ankle",
+        "Crew",
+        "Knee High",
+        "Mid Calf",
+        "No Show",
+        "Over the Knee",
+        "Thigh High"
+      ],
+      "can_have_unknown_value": true,
+      "fieldname": "SockRise",
+      "key": "sock_rise",
+      "recommended": false,
+      "description": "The height style of socks."
+    },
+    "bde7f38a6a5fa76697d288227050040e": {
+      "type": "string",
+      "example": ["Golden State Warriors"],
+      "can_have_multiple_values": true,
+      "fieldname": "SportsLeague",
+      "key": "sports_league",
+      "recommended": false,
+      "description": "The particular sports league that your item represents or is associated with."
+    },
+    "f87289e65273a3a8c33c2fd3dc5b6d4b": {
+      "type": "string",
+      "example": ["NFL"],
+      "can_have_multiple_values": true,
+      "fieldname": "SportsTeam",
+      "key": "sports_team",
+      "recommended": false,
+      "description": "The particular sports team that your item represents or is associated with."
+    },
+    "a9dc83480290657ae724a1d0fe346563": {
+      "type": "enum",
+      "example": ["Water Resistant"],
+      "can_have_multiple_values": true,
+      "enum_values": ["Waterproof", "Water Resistant"],
+      "can_have_unknown_value": false,
+      "fieldname": "StandardFeatures",
+      "key": "standard_features",
+      "recommended": false,
+      "description": "Standard features related to your item that might be important for buyers."
+    },
+    "790ed72ed6a00633b47d5959d9869e00": {
+      "type": "string",
+      "example": "Racerback",
+      "can_have_multiple_values": false,
+      "fieldname": "UpperBodyStrapConfiguration",
+      "key": "upper_body_strap_configuration",
+      "recommended": false,
+      "description": "The strap style for items like tops, bras, and swimsuits."
+    },
+    "8b9b340f74a391da8163b1edfbaeeef9": {
+      "type": "string",
+      "example": "Ultra High",
+      "can_have_multiple_values": false,
+      "fieldname": "WaistRise",
+      "key": "waist_rise",
+      "recommended": false,
+      "description": "The height where the waistline of the item lies on the body."
+    },
+    "ed9805103a40909dbd170d6a15d59e57": {
+      "type": "measurement",
+      "example": "30 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "WaistSize",
+      "key": "waist_size",
+      "recommended": false,
+      "description": "The numeric size of the waist for lower body garments. Does not include generic sizes like Small."
+    },
+    "59d583067536c9a9f0092ad4349b4107": {
+      "type": "string",
+      "example": "Opaque",
+      "can_have_multiple_values": false,
+      "fieldname": "Sheerness",
+      "key": "sheerness",
+      "recommended": false,
+      "description": "The amount of sheerness or opacity of an item. Usually used for hosiery items."
+    },
+    "5917325df899badf730967031c51828e": {
+      "type": "string",
+      "example": "Relaxed",
+      "can_have_multiple_values": false,
+      "fieldname": "PantFit",
+      "key": "pant_fit",
+      "recommended": false,
+      "description": "The general fit style of pants. Also applies to jeans."
+    },
+    "5d2faf8e7cd918c37585a3582ce67d41": {
+      "type": "string",
+      "example": "Ankle",
+      "can_have_multiple_values": false,
+      "fieldname": "PantLengthStyle",
+      "key": "pant_length_style",
+      "recommended": false,
+      "description": "The length style of pants. Also applies to jeans & leggings."
+    },
+    "79d33c7a4244cde541284dffebd8af57": {
+      "type": "string",
+      "example": ["Distressed", "Faded"],
+      "can_have_multiple_values": true,
+      "fieldname": "DenimFeatures",
+      "key": "denim_features",
+      "recommended": false,
+      "description": "Features, embellishments & finishes that are specific to jeans."
+    },
+    "088788414687d075b58111bf0a9e6b28": {
+      "type": "integer",
+      "example": 32,
+      "can_have_multiple_values": false,
+      "fieldname": "BraBandSize",
+      "key": "bra_band_size",
+      "recommended": false,
+      "description": "The band size of the bra."
+    },
+    "f8cd81278f0a424f4552e69119f8ce3e": {
+      "type": "string",
+      "example": "A",
+      "can_have_multiple_values": false,
+      "fieldname": "BraCupSize",
+      "key": "bra_cup_size",
+      "recommended": false,
+      "description": "The cup size of the bra."
+    },
+    "3eb05a953435b526264c76134a8b02df": {
+      "type": "measurement",
+      "example": "34 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "ChestSize",
+      "key": "chest_size",
+      "recommended": false,
+      "description": "The numeric size of the chest measurement for the item. Does not include generic sizes like Small."
+    },
+    "7951a620026294a95a0ac44f9ba71eee": {
+      "type": "string",
+      "example": "Zipper",
+      "can_have_multiple_values": false,
+      "fieldname": "Closure",
+      "key": "closure",
+      "recommended": false,
+      "description": "The type of fastener used to close your item."
+    },
+    "114da48906462d334d5d7f59893d434d": {
+      "type": "enum",
+      "example": "Big & Tall",
+      "can_have_multiple_values": false,
+      "enum_values": [
+        "Big & Tall",
+        "Regular",
+        "Big Boys",
+        "Big Girls",
+        "Full Size",
+        "Little Boys",
+        "Little Girls",
+        "Petite",
+        "Plus",
+        "Maternity",
+        "Baby Boy",
+        "Baby Girls",
+        "Toddler Boys",
+        "Toddler Girls"
+      ],
+      "can_have_unknown_value": true,
+      "fieldname": "ClothingSizeType",
+      "key": "clothing_size_type",
+      "recommended": false,
+      "description": "The general grouping of different sizes based on age & gender."
+    },
+    "e1cc3ced186fc459db4f1778dabbc6c0": {
+      "type": "string",
+      "example": "Banded",
+      "can_have_multiple_values": false,
+      "fieldname": "CollarStyle",
+      "key": "collar_style",
+      "recommended": false,
+      "description": "The style of collar on your item."
+    },
+    "07a68126da1326bbb99e0ffd81455258": {
+      "type": "string",
+      "example": ["Do Not Iron", "Dry Clean Only"],
+      "can_have_multiple_values": true,
+      "fieldname": "FabricCareInstructions",
+      "key": "fabric_care_instructions",
+      "recommended": false,
+      "description": "The specific care instructions for how the fabric of your item should be cleaned. This can be found on the label of the item."
+    },
+    "c4398a3afbb4b58166ab7090026a1c5f": {
+      "type": "string",
+      "example": "Boot Cut",
+      "can_have_multiple_values": false,
+      "fieldname": "PantLegStyle",
+      "key": "pant_leg_style",
+      "recommended": false,
+      "description": "The style or cut of pant legs. Also applies to jeans."
+    },
+    "8908691dbe1fc7cf9b8ec543a30ccf74": {
+      "type": "measurement",
+      "example": "30 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "Inseam",
+      "key": "inseam",
+      "recommended": false,
+      "description": "The numeric size of the inseam for items like pants, jeans and leggings. Does not include generic sizes like Small."
+    },
+    "0c682655422cf862d012da48c74e9045": {
+      "type": "boolean",
+      "example": "yes",
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "enum_values": ["yes", "no"],
+      "fieldname": "IsAdultProduct",
+      "key": "is_adult_product",
+      "recommended": false,
+      "description": "Indicates if your product is sexually suggestive and intended only for adults."
+    },
+    "e32d81cb2795fb799d41e9beb75914a1": {
+      "type": "boolean",
+      "example": "yes",
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "enum_values": ["yes", "no"],
+      "fieldname": "IsCostume",
+      "key": "is_costume",
+      "recommended": false,
+      "description": "Indicates if the item is intended to be worn as a costume."
+    },
+    "044e1e8f4a2fb735e0f63e44c3217379": {
+      "type": "boolean",
+      "example": "yes",
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "enum_values": ["yes", "no"],
+      "fieldname": "IsOutfitSet",
+      "key": "is_outfit_set",
+      "recommended": false,
+      "description": "Indicates if the product has 2 or more different items that come as part of a matching or oufit set, like matching shirt & pants or bra & underwear set"
+    },
+    "11c967a5fc1a473d71ba4e8ac43d35c4": {
+      "type": "string",
+      "example": "Acid Wash",
+      "can_have_multiple_values": false,
+      "fieldname": "JeanWash",
+      "key": "jean_wash",
+      "recommended": false,
+      "description": "The post-process wash treatment that may alter color or texture of denim products."
+    },
+    "f26b323c65bc8413143b53c424cb106c": {
+      "type": "string",
+      "example": "Crew Neck",
+      "can_have_multiple_values": false,
+      "fieldname": "Neckline",
+      "key": "neckline",
+      "recommended": false,
+      "description": "The neckline or neck style of the item."
+    },
+    "efe63cfc2af39e9b3904b04f339137a8": {
+      "type": "string",
+      "example": ["Bridesmaid"],
+      "can_have_multiple_values": true,
+      "fieldname": "Occasion",
+      "key": "occasion",
+      "recommended": false,
+      "description": "The type of special occassion(s) for which your item is intended or specialized."
+    },
+    "00efcecb28226b61fa715ceed2408546": {
+      "type": "string",
+      "example": "Banded",
+      "can_have_multiple_values": false,
+      "fieldname": "WaistStyle",
+      "key": "waist_style",
+      "recommended": false,
+      "description": "The style of the waist on the item. Can apply to pants or dresses."
+    },
+    "f8b8550acb981fe24299736073b56104": {
+      "type": "string",
+      "example": ["Bow Tie"],
+      "can_have_multiple_values": true,
+      "fieldname": "Style",
+      "key": "style",
+      "recommended": true,
+      "description": "The style(s) associated with the item."
+    },
+    "a53318a479999a52de362427c1af31da": {
+      "type": "string",
+      "example": "Narrow",
+      "can_have_multiple_values": false,
+      "fieldname": "SunglassesWidth",
+      "key": "sunglasses_width",
+      "recommended": false,
+      "description": "The width of the sunglasses frame."
+    },
+    "422e14c47d8c95351a13574b5ffe3076": {
+      "type": "string",
+      "example": "Anti-Reflective",
+      "can_have_multiple_values": false,
+      "fieldname": "SunglassesLensTechnology",
+      "key": "sunglasses_lens_technology",
+      "recommended": false,
+      "description": "The technology or treatment of sunglasses lenses."
+    },
+    "36415ae546c8d7681c9ede23fdc1ddc3": {
+      "type": "enum",
+      "example": "Beige",
+      "can_have_multiple_values": false,
+      "enum_values": [
+        "Beige",
+        "Black",
+        "Blue",
+        "Bronze",
+        "Brown",
+        "Gold",
+        "Gray",
+        "Green",
+        "Multi-Color",
+        "Orange",
+        "Pink",
+        "Purple",
+        "Red",
+        "Silver",
+        "White",
+        "Yellow"
+      ],
+      "can_have_unknown_value": true,
+      "fieldname": "SunglassesLensColor",
+      "key": "sunglasses_lens_color",
+      "recommended": false,
+      "description": "The color of sunglasses lenses."
+    },
+    "70c39caa59cfd987167f972dd9aba990": {
+      "type": "string",
+      "example": "Classic",
+      "can_have_multiple_values": false,
+      "fieldname": "TieWidth",
+      "key": "tie_width",
+      "recommended": false,
+      "description": "The width of tie."
+    },
+    "8125fc680ed8690436264f94a52dd4e9": {
+      "type": "string",
+      "example": ["Chukka"],
+      "can_have_multiple_values": true,
+      "fieldname": "Style",
+      "key": "style",
+      "recommended": true,
+      "description": "The style(s) associated with the item."
+    },
+    "cd9f78020f15de834fcc58d3d563ebac": {
+      "type": "string",
+      "example": "A",
+      "can_have_multiple_values": false,
+      "fieldname": "ShoeWidth",
+      "key": "shoe_width",
+      "recommended": true,
+      "description": "The width of the shoes."
+    },
+    "b0bd5a2777af18be80307b03175a050a": {
+      "type": "enum",
+      "example": ["Water Resistant"],
+      "can_have_multiple_values": true,
+      "enum_values": ["Orthopedic", "Waterproof", "Water Resistant"],
+      "can_have_unknown_value": false,
+      "fieldname": "StandardFeatures",
+      "key": "standard_features",
+      "recommended": false,
+      "description": "Standard features related to your item that might be important for buyers."
+    },
+    "30bc46e76de465db006632f51b9dc9bc": {
+      "type": "enum",
+      "example": "Flats",
+      "can_have_multiple_values": false,
+      "enum_values": [
+        "Flats",
+        "Boots",
+        "Heels",
+        "Sandals",
+        "Slippers",
+        "Athletic Shoes",
+        "Fashion Sneakers"
+      ],
+      "can_have_unknown_value": true,
+      "fieldname": "ShoeType",
+      "key": "shoe_type",
+      "recommended": false,
+      "description": "The type of shoes."
+    },
+    "eb7731477ae172c98b8653d26038d351": {
+      "type": "string",
+      "example": "Wedge",
+      "can_have_multiple_values": false,
+      "fieldname": "HeelStyle",
+      "key": "heel_style",
+      "recommended": false,
+      "description": "The style of heel on the shoes."
+    },
+    "9847453e3dfb3f97dd262911e96927fc": {
+      "type": "measurement",
+      "example": "0.5 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "HeelHeight",
+      "key": "heel_height",
+      "recommended": false,
+      "description": "The numeric height of the heel on the shoes."
+    },
+    "24cdfc97c883070990bfe53a9ab4fcc1": {
+      "type": "string",
+      "example": ["Hoops"],
+      "can_have_multiple_values": true,
+      "fieldname": "Style",
+      "key": "style",
+      "recommended": true,
+      "description": "The style(s) associated with the item."
+    },
+    "ae3548dbfd62e601abeefe809b9804fe": {
+      "type": "string",
+      "example": ["Ruby", "Emerald"],
+      "can_have_multiple_values": true,
+      "fieldname": "Gemstone",
+      "key": "gemstone",
+      "recommended": true,
+      "description": "The type of gemstone(s) in your item."
+    },
+    "c2b8ee902fdca1b35815f183af905f6a": {
+      "type": "string",
+      "example": ["Vintage", "Engraved"],
+      "can_have_multiple_values": true,
+      "fieldname": "AdditionalFeatures",
+      "key": "additional_features",
+      "recommended": false,
+      "description": "Additional features related to your item that might be important for buyers."
+    },
+    "f0933d6a49ace1948a6f904be052d459": {
+      "type": "enum",
+      "example": ["Resizable"],
+      "can_have_multiple_values": true,
+      "enum_values": ["Resizable", "Water Resistant"],
+      "can_have_unknown_value": false,
+      "fieldname": "StandardFeatures",
+      "key": "standard_features",
+      "recommended": false,
+      "description": "Standard features related to your item that might be important for buyers."
+    },
+    "0a55223a8807dfafc4e957899053f571": {
+      "type": "string",
+      "example": "Silver",
+      "can_have_multiple_values": false,
+      "fieldname": "PlatingMaterial",
+      "key": "plating_material",
+      "recommended": false,
+      "description": "The type of metal or material which your item is plated or covered with."
+    },
+    "deb41e4835824a3ada806d318df5ffe0": {
+      "type": "string",
+      "example": "14k",
+      "can_have_multiple_values": false,
+      "fieldname": "MetalStampOrPurity",
+      "key": "metal_stamp_or_purity",
+      "recommended": false,
+      "description": "The metal purity of your item. Sometimes this is indicated or stamped directly onto jewelry items."
+    },
+    "6e7562a9f0a1c4675f7ca5d15cf53e6a": {
+      "type": "string",
+      "example": "2 prong",
+      "can_have_multiple_values": false,
+      "fieldname": "JewelrySettingStyle",
+      "key": "jewelry_setting_style",
+      "recommended": false,
+      "description": "The style in which stones are set within or attached to a piece of jewelry"
+    },
+    "f0f118d833eecf0a3d4deb47ce1e8a2a": {
+      "type": "string",
+      "example": ["Best Friends Forever"],
+      "can_have_multiple_values": true,
+      "fieldname": "Inscription",
+      "key": "inscription",
+      "recommended": false,
+      "description": "The text of what is engraved on the item. (Multiple Values Accepted)"
+    },
+    "3ed35b95494c9b3f2985fdb9dff7730d": {
+      "type": "string",
+      "example": 1.29,
+      "can_have_multiple_values": false,
+      "fieldname": "GemstoneWeight",
+      "key": "gemstone_weight",
+      "recommended": false,
+      "description": "The total weight or mass (in carats) of the individual gemstone."
+    },
+    "58ba4a0325e3756373a8383a2bc5377d": {
+      "type": "string",
+      "example": 5,
+      "can_have_multiple_values": false,
+      "fieldname": "GemstoneWidth",
+      "key": "gemstone_width",
+      "recommended": false,
+      "description": "The width measurement of the gemstone in milimeters."
+    },
+    "8e0135de1890e1bc54c6f4524d2bb6a1": {
+      "type": "string",
+      "example": ["Dyed", "Heat Treated"],
+      "can_have_multiple_values": true,
+      "fieldname": "GemstoneTreatment",
+      "key": "gemstone_treatment",
+      "recommended": false,
+      "description": "Indicates any treatments or processing of the stone to change its color, clarity or durability."
+    },
+    "af11df6c0242d4276dc13b175379b723": {
+      "type": "string",
+      "example": 5,
+      "can_have_multiple_values": false,
+      "fieldname": "GemstoneLength",
+      "key": "gemstone_length",
+      "recommended": false,
+      "description": "The length measurement of the gemstone in milimeters."
+    },
+    "8f70200f0fd2e1a7987947575021f910": {
+      "type": "string",
+      "example": 5,
+      "can_have_multiple_values": false,
+      "fieldname": "GemstoneHeight",
+      "key": "gemstone_height",
+      "recommended": false,
+      "description": "The height measurement of the gemstone in milimeters."
+    },
+    "6ad2f369b3c9e5177d46ce54aaa855e3": {
+      "type": "string",
+      "example": "Asscher",
+      "can_have_multiple_values": false,
+      "fieldname": "GemstoneCut",
+      "key": "gemstone_cut",
+      "recommended": false,
+      "description": "The style in which the gemstone(s) of your item have been cut and their general shape."
+    },
+    "be0f716b198ea39563b1ae49c03feaa7": {
+      "type": "string",
+      "example": "Natural",
+      "can_have_multiple_values": false,
+      "fieldname": "GemstoneCreationMethod",
+      "key": "gemstone_creation_method",
+      "recommended": false,
+      "description": "The method by which the stone was created. Indicates if the stone is natural or manmade."
+    },
+    "087b63be2ec0b2c73fdeb21260a8429e": {
+      "type": "string",
+      "example": "Colorless",
+      "can_have_multiple_values": false,
+      "fieldname": "GemstoneColor",
+      "key": "gemstone_color",
+      "recommended": false,
+      "description": "The color of the gemstone(s) in your item that accounts for hue, tone and saturation."
+    },
+    "40496e7589d7a3e945471afaa9b5eb77": {
+      "type": "string",
+      "example": "FL",
+      "can_have_multiple_values": false,
+      "fieldname": "GemstoneClarity",
+      "key": "gemstone_clarity",
+      "recommended": false,
+      "description": "The quality and clarity of the visual aspect of the gemstone, particularly important for Diamonds. Indicates visual and and internal characteristics and surface defects of blemishes."
+    },
+    "3b714bc4f27197b27df4ed555063b227": {
+      "type": "string",
+      "example": "Clip-On",
+      "can_have_multiple_values": false,
+      "fieldname": "EarringBackFinding",
+      "key": "earring_back_finding",
+      "recommended": false,
+      "description": "The type of fastening method for the backs of earrings."
+    },
+    "2a4450be3608cf3a38cad25f7d49b813": {
+      "type": "string",
+      "example": "Lobster Clasp",
+      "can_have_multiple_values": false,
+      "fieldname": "ClaspType",
+      "key": "clasp_type",
+      "recommended": false,
+      "description": "The type of clasp or closure method of your item."
+    },
+    "b8b24c8698213706e91fb53948de8a69": {
+      "type": "measurement",
+      "example": "12 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "ChainLength",
+      "key": "chain_length",
+      "recommended": false,
+      "description": "The length of the jewelry chain. Usually in inches."
+    },
+    "2ad129e62056d93bd1201aef398651bb": {
+      "type": "string",
+      "example": 1.29,
+      "can_have_multiple_values": false,
+      "fieldname": "TotalGemstoneWeight",
+      "key": "total_gemstone_weight",
+      "recommended": false,
+      "description": "The total combined weight or mass (in carats) of all stones in the piece of jewelry."
+    },
+    "d9e0fd21a2211dee29551f555ae1036d": {
+      "type": "string",
+      "example": ["Bangle"],
+      "can_have_multiple_values": true,
+      "fieldname": "Style",
+      "key": "style",
+      "recommended": true,
+      "description": "The style(s) associated with the item."
+    },
+    "cf48a2e1304c7e8e3df5e6a9eb67e991": {
+      "type": "enum",
+      "example": "Electric",
+      "can_have_multiple_values": false,
+      "enum_values": ["Electric", "Batteries"],
+      "can_have_unknown_value": true,
+      "fieldname": "PowerType",
+      "key": "power_type",
+      "recommended": false,
+      "description": "Provides information on the exact type of power used by the item."
+    },
+    "abfc9636c9dd70941b01e4e077588073": {
+      "type": "enum",
+      "example": ["Calendar"],
+      "can_have_multiple_values": true,
+      "enum_values": ["Calendar", "Resizable", "Water Resistant", "Waterproof"],
+      "can_have_unknown_value": false,
+      "fieldname": "StandardFeatures",
+      "key": "standard_features",
+      "recommended": false,
+      "description": "Standard features related to your item that might be important for buyers."
+    },
+    "0f94d987d41ce3cc234ca9051c468234": {
+      "type": "measurement",
+      "example": "240 mm",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "WatchBandLength",
+      "key": "watch_band_length",
+      "recommended": false,
+      "description": "The length of the watch band"
+    },
+    "8ea77ea069e2c0b4b74c167d9e394faf": {
+      "type": "string",
+      "example": ["Leather", "Stainless Steel"],
+      "can_have_multiple_values": true,
+      "fieldname": "WatchBandMaterial",
+      "key": "watch_band_material",
+      "recommended": false,
+      "description": "The primary material(s) from which the band of the watch is made."
+    },
+    "d3ac14e44af9ea925fd801578da42a63": {
+      "type": "measurement",
+      "example": "22 mm",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "WatchBandWidth",
+      "key": "watch_band_width",
+      "recommended": false,
+      "description": "The width of the watch band"
+    },
+    "028cde57179c9c4356a63649d170c6c4": {
+      "type": "measurement",
+      "example": "42 mm",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "WatchCaseDiameter",
+      "key": "watch_case_diameter",
+      "recommended": false,
+      "description": "The diameter of the watch case or dial"
+    },
+    "f4b65f0456fd44dd79accf30fa6002f6": {
+      "type": "string",
+      "example": "Round",
+      "can_have_multiple_values": false,
+      "fieldname": "WatchCaseShape",
+      "key": "watch_case_shape",
+      "recommended": false,
+      "description": "The shape of the watch case or enclosure which contains the face & inner workings of the watch."
+    },
+    "37da4cf70f57a2eaf2671145d216b16e": {
+      "type": "measurement",
+      "example": "12 mm",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "WatchCaseThickness",
+      "key": "watch_case_thickness",
+      "recommended": false,
+      "description": "The thickness of the watch case or dial"
+    },
+    "eba94cf3d4446cdb773987c97f384918": {
+      "type": "string",
+      "example": ["Yoga", "Sailing"],
+      "can_have_multiple_values": true,
+      "fieldname": "Activity",
+      "key": "activity",
+      "recommended": false,
+      "description": "The particular sport or activity for which your item is intended."
+    },
+    "44084d5972f3b03d6abe5887c6dfd4b0": {
+      "type": "string",
+      "example": ["Ruby", "Emerald"],
+      "can_have_multiple_values": true,
+      "fieldname": "Gemstone",
+      "key": "gemstone",
+      "recommended": false,
+      "description": "The type of gemstone(s) in your item."
+    },
+    "9a6f633320e996ae1d5bad38d51e085c": {
+      "type": "string",
+      "example": "Quartz",
+      "can_have_multiple_values": false,
+      "fieldname": "WatchMovementType",
+      "key": "watch_movement_type",
+      "recommended": false,
+      "description": "The type of movement within the watch"
+    },
+    "fe4c9e79e3986fe439f5ba1c21828f2e": {
+      "type": "measurement",
+      "example": "1 TB",
+      "enum_values": ["KB", "MB", "GB", "TB"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "StorageCapacity",
+      "key": "storage_capacity",
+      "recommended": true,
+      "description": "Describes the amount of storage space on the item's hard drive, typically measured in megabytes, gigabytes or terabytes."
+    },
+    "2390176fad8a47f031329e771da0e400": {
+      "type": "string",
+      "example": "Android",
+      "can_have_multiple_values": false,
+      "fieldname": "OperatingSystem",
+      "key": "operating_system",
+      "recommended": true,
+      "description": "Describes the type of preloaded operating system software installed on the device."
+    },
+    "49b1cf42befb0ba138e430326fbc6ea6": {
+      "type": "measurement",
+      "example": "42 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "ScreenSize",
+      "key": "screen_size",
+      "recommended": true,
+      "description": "Describes the measurement of the device's screen, typically measured diagonally in inches."
+    },
+    "567aba0d72ce14b0928d5e6aa61c7f35": {
+      "type": "string",
+      "example": 24,
+      "can_have_multiple_values": false,
+      "fieldname": "RearFacingCameraResolution",
+      "key": "rear_facing_camera_resolution",
+      "recommended": false,
+      "description": "Describes the maximum resolution of the item's rear facing camera, in megapixels."
+    },
+    "a5dc22c3e935ab432331f4cab30c0787": {
+      "type": "measurement",
+      "example": "3 GHz",
+      "enum_values": ["Hz", "KHz", "MHz", "GHz"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "ProcessorSpeed",
+      "key": "processor_speed",
+      "recommended": false,
+      "description": "Describes the operational frequency of the computer's CPU"
+    },
+    "361b07f5140feaec4be03122ed0d6287": {
+      "type": "string",
+      "example": "Intel Core i7",
+      "can_have_multiple_values": false,
+      "fieldname": "ProcessorType",
+      "key": "processor_type",
+      "recommended": false,
+      "description": "Describes commonly used name of the computer's CPU"
+    },
+    "fe18897b738f817319015eb3048928e5": {
+      "type": "measurement",
+      "example": "16 GB",
+      "enum_values": ["KB", "MB", "GB", "TB"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "RamMemory",
+      "key": "ram_memory",
+      "recommended": false,
+      "description": "Desribes the amount of RAM memory that is preinstalled on the product."
+    },
+    "083cb9b61b45283ca9ee93f906516300": {
+      "type": "integer",
+      "example": 1080,
+      "can_have_multiple_values": false,
+      "fieldname": "Resolution",
+      "key": "resolution",
+      "recommended": false,
+      "description": "Describes the resolution of the product screen"
+    },
+    "a59afd07b13fe423f4ea99faec8453d8": {
+      "type": "string",
+      "example": 24,
+      "can_have_multiple_values": false,
+      "fieldname": "VideoResolution",
+      "key": "video_resolution",
+      "recommended": false,
+      "description": "Describes the resolution of the video recordings of the product in\n        megapixels"
+    },
+    "3b621ecd047fb5f084be32fc1afb6389": {
+      "type": "string",
+      "example": "ATX",
+      "can_have_multiple_values": false,
+      "fieldname": "MotherboardFormFactor",
+      "key": "motherboard_form_factor",
+      "recommended": false,
+      "description": "Describes one of the standard physical sizes to which the computer motherboard conforms"
+    },
+    "bfe5d2ed096364fe145cc59a87f41760": {
+      "type": "string",
+      "example": ["CD ROM"],
+      "can_have_multiple_values": true,
+      "fieldname": "OpticalDrive",
+      "key": "optical_drive",
+      "recommended": false,
+      "description": "Describes the type of optical drives included with the product"
+    },
+    "ec6456439bf772caeb9e8304cb32ec3e": {
+      "type": "measurement",
+      "example": "16 GB",
+      "enum_values": ["KB", "MB", "GB", "TB"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "MaximumSupportedRam",
+      "key": "maximum_supported_ram",
+      "recommended": false,
+      "description": "Describes the maximum amount of RAM memory that can be supported by the product."
+    },
+    "70d088a2087eeddc317dedc4846e71e1": {
+      "type": "enum",
+      "example": "Internal",
+      "can_have_multiple_values": false,
+      "enum_values": ["Internal", "External"],
+      "can_have_unknown_value": true,
+      "fieldname": "HardDriveType",
+      "key": "hard_drive_type",
+      "recommended": false,
+      "description": "Describes whether the hard drives of the product are internal or external"
+    },
+    "4a2d5d0019d9f4e3e553461d450eb409": {
+      "type": "string",
+      "example": "Nvidia GeForce RTX 2080",
+      "can_have_multiple_values": false,
+      "fieldname": "GraphicsCardModel",
+      "key": "graphics_card_model",
+      "recommended": false,
+      "description": "Describes the model name of the graphics card included with the product"
+    },
+    "ea1ec0d2e16be590eee6a2ede6da6435": {
+      "type": "string",
+      "example": 24,
+      "can_have_multiple_values": false,
+      "fieldname": "FrontFacingCameraResolution",
+      "key": "front_facing_camera_resolution",
+      "recommended": false,
+      "description": "Describes the maximum resolution of the item's front facing camera, in megapixels."
+    },
+    "b6049f7a7d322c6402d8e55ff0041d93": {
+      "type": "string",
+      "example": "AM3",
+      "can_have_multiple_values": false,
+      "fieldname": "CpuSocketType",
+      "key": "cpu_socket_type",
+      "recommended": false,
+      "description": "The interface of, or required by, the central processing unit."
+    },
+    "54919ad5f3d7792c8e13c4bde36632bf": {
+      "type": "string",
+      "example": "Full Tower",
+      "can_have_multiple_values": false,
+      "fieldname": "ComputerCaseFormFactor",
+      "key": "computer_case_form_factor",
+      "recommended": false,
+      "description": "Describes one of the standard physical sizes to which the computer case conforms"
+    },
+    "b31777d6275a27c26f1e9928c503ef19": {
+      "type": "string",
+      "example": "Bluetooth 4.0",
+      "can_have_multiple_values": false,
+      "fieldname": "BluetoothTechnology",
+      "key": "bluetooth_technology",
+      "recommended": false,
+      "description": "Describes the type of version of the compatible bluetooth."
+    },
+    "dacac94d354a921cff590fa3d34d6078": {
+      "type": "string",
+      "example": 12,
+      "can_have_multiple_values": false,
+      "fieldname": "StandbyTime",
+      "key": "standby_time",
+      "recommended": false,
+      "description": "Describes the total stand-by time in hours of the phone."
+    },
+    "ed57863b87213a9ffe54d40f978635b8": {
+      "type": "string",
+      "example": 12,
+      "can_have_multiple_values": false,
+      "fieldname": "TalkTime",
+      "key": "talk_time",
+      "recommended": false,
+      "description": "Describes the total talk time in hours of the phone."
+    },
+    "643ec7fd851671f9f0fe60199b37bf0c": {
+      "type": "string",
+      "example": ["Leather"],
+      "can_have_multiple_values": true,
+      "fieldname": "WatchBandMaterial",
+      "key": "watch_band_material",
+      "recommended": false,
+      "description": "The materials from which the band of the watch is made."
+    },
+    "d0aae07685ed17d8f4d00a2658fbb437": {
+      "type": "string",
+      "example": ["Standard SIM"],
+      "can_have_multiple_values": true,
+      "fieldname": "SimTypes",
+      "key": "sim_types",
+      "recommended": false,
+      "description": "Describes the type of SIM compatible with the product, like Mini-SIM, Dual SIM."
+    },
+    "f2d22b905571ec1b0c9722ed6c227125": {
+      "type": "integer",
+      "example": 1,
+      "can_have_multiple_values": false,
+      "fieldname": "NumberofSIMCardSlots",
+      "key": "numberof_s_i_m_card_slots",
+      "recommended": false,
+      "description": "Describes the number of SIM card slots on the product."
+    },
+    "7c8efd858532f7cdf437cc9fb39a0bec": {
+      "type": "string",
+      "example": "3G",
+      "can_have_multiple_values": false,
+      "fieldname": "CellularGeneration",
+      "key": "cellular_generation",
+      "recommended": false,
+      "description": " Describes the communications network generation of the cell phone"
+    },
+    "65fe00497801a23a1285c1bdfba66014": {
+      "type": "string",
+      "example": "CDMA",
+      "can_have_multiple_values": false,
+      "fieldname": "CellularBand",
+      "key": "cellular_band",
+      "recommended": false,
+      "description": "Describes the cellular band or network technology used by the device."
+    },
+    "fe1280e0d1b522e738d01296e5efb34f": {
+      "type": "string",
+      "example": "Verizon",
+      "can_have_multiple_values": false,
+      "fieldname": "CellPhoneServiceProvider",
+      "key": "cell_phone_service_provider",
+      "recommended": false,
+      "description": "Describes the company that provides the phone's cellular service (if not unlocked)"
+    },
+    "bbc7f8045d5073625f856ac52313df47": {
+      "type": "string",
+      "example": "Wristwatch",
+      "can_have_multiple_values": false,
+      "fieldname": "WatchStyle",
+      "key": "watch_style",
+      "recommended": false,
+      "description": "The style of watch."
+    },
+    "707d4ddb458001de9dd489dc081a917a": {
+      "type": "string",
+      "example": ["iPad"],
+      "can_have_multiple_values": true,
+      "fieldname": "CompatibleDevices",
+      "key": "compatible_devices",
+      "recommended": true,
+      "description": "Devices compatible with the item."
+    },
+    "30c69d289f07754985fa521022655ba0": {
+      "type": "measurement",
+      "example": "10 g",
+      "enum_values": ["mg", "g", "kg", "oz", "lb"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "ProductWeight",
+      "key": "product_weight",
+      "recommended": false,
+      "description": "The weight of the fully assembled product."
+    },
+    "10a6af510a4d49ca6eeaebfbead6c6fa": {
+      "type": "measurement",
+      "example": "40 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "MinimumScreenSize",
+      "key": "minimum_screen_size",
+      "recommended": false,
+      "description": " Describes the minimum size of the TV/Monitor that the mount can\n          accommodate"
+    },
+    "b1bac032a961eb0cff6df86fce2da4c4": {
+      "type": "string",
+      "example": "Fixed Mount",
+      "can_have_multiple_values": false,
+      "fieldname": "MountType",
+      "key": "mount_type",
+      "recommended": false,
+      "description": "Describes how the TV or monitor is attached and degree of\n        adjustment of position is allowed once the mount is installed"
+    },
+    "bdcaca96c46e181c0d4bf347097c228e": {
+      "type": "measurement",
+      "example": "55 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "MaximumScreenSize",
+      "key": "maximum_screen_size",
+      "recommended": false,
+      "description": "Describes the maximum size of the TV/Monitor that the mount can\n          accommodate"
+    },
+    "ec7db52e6443df6d84672fa3397e4144": {
+      "type": "measurement",
+      "example": "45 lb",
+      "enum_values": ["mg", "g", "kg", "oz", "lb"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "MaxLoadWeight",
+      "key": "max_load_weight",
+      "recommended": false,
+      "description": "Describes the amount of weight that the TV/Monitor mount\n        can support as certified by the manufacturer"
+    },
+    "91f569f41bdde8d40c421f04d9f0ec23": {
+      "type": "string",
+      "example": ["In-Ear"],
+      "can_have_multiple_values": true,
+      "fieldname": "HeadphoneFeatures",
+      "key": "headphone_features",
+      "recommended": false,
+      "description": "List features specific to headphones"
+    },
+    "158bcad2efdd1b1f944e632d8603c189": {
+      "type": "measurement",
+      "example": "2 ft",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "CableLength",
+      "key": "cable_length",
+      "recommended": false,
+      "description": "Total length of electronics cable"
+    },
+    "8904e34635ccfa9f1776f6bf8964d571": {
+      "type": "measurement",
+      "example": "10 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "ProductDepth",
+      "key": "product_depth",
+      "recommended": true,
+      "description": "The depth of the fully assembled product."
+    },
+    "1e86882555078459f4919858583e9fce": {
+      "type": "integer",
+      "example": 1080,
+      "can_have_multiple_values": false,
+      "fieldname": "Resolution",
+      "key": "resolution",
+      "recommended": true,
+      "description": "Describes the resolution of the product screen"
+    },
+    "75bf93f645a2702cd3dc1aeac96fcc79": {
+      "type": "integer",
+      "example": 50,
+      "can_have_multiple_values": false,
+      "fieldname": "MonochromePagesPerMinute",
+      "key": "monochrome_pages_per_minute",
+      "recommended": false,
+      "description": "The number of monochrome pages that the imaging device is able to produce per minute."
+    },
+    "bf9c9a51c205f8c02070a7aa2e11d65b": {
+      "type": "enum",
+      "example": "Monochrome",
+      "can_have_multiple_values": false,
+      "enum_values": ["Monochrome", "Color"],
+      "can_have_unknown_value": true,
+      "fieldname": "MonochromeOrColor",
+      "key": "monochrome_or_color",
+      "recommended": false,
+      "description": "Is the imaging device capable of color processing or monochrome only?"
+    },
+    "eefa8dd52fadfc95322a8c584a87e1c5": {
+      "type": "integer",
+      "example": 12,
+      "can_have_multiple_values": false,
+      "fieldname": "ColorPagesPerMinute",
+      "key": "color_pages_per_minute",
+      "recommended": false,
+      "description": "The number of color pages that the imaging device is able to produce per minute."
+    },
+    "be84c1ccb42a2826aa12efb3ad494d6e": {
+      "type": "string",
+      "example": "LCD",
+      "can_have_multiple_values": false,
+      "fieldname": "DisplayTechnology",
+      "key": "display_technology",
+      "recommended": true,
+      "description": "Describes the type of technology that powers the display, like LED or LCD."
+    },
+    "fece1f8c30e55cec967050c8d46d2179": {
+      "type": "string",
+      "example": 5,
+      "can_have_multiple_values": false,
+      "fieldname": "ResponseTime",
+      "key": "response_time",
+      "recommended": false,
+      "description": "Describes the amount of time it takes for the pixels in a display to change, measured in miliseconds."
+    },
+    "d2b0fda41f2dc69846c9a72ee97b6304": {
+      "type": "string",
+      "example": 60,
+      "can_have_multiple_values": false,
+      "fieldname": "RefreshRate",
+      "key": "refresh_rate",
+      "recommended": false,
+      "description": "Describes the refresh rate of the display. This measures the number of times the picture is updated per second, measured in Hz."
+    },
+    "0307a27632bdff957e247336e336c958": {
+      "type": "string",
+      "example": "200 x 200",
+      "can_have_multiple_values": false,
+      "fieldname": "VesaMountingStandard",
+      "key": "vesa_mounting_standard",
+      "recommended": false,
+      "description": "The VESA Standard defines the distance in millimeters between the\n          four mounting holes on the back of a TV (distance horizontally x\n          distance vertically)."
+    },
+    "0ea98808c27886d1dae8ceaa3aaa2260": {
+      "type": "string",
+      "example": "4:3",
+      "can_have_multiple_values": false,
+      "fieldname": "AspectRatio",
+      "key": "aspect_ratio",
+      "recommended": false,
+      "description": "Describes the relationship between the product's width and its height."
+    },
+    "0abb978f2c8edd1d059e564a4e41e744": {
+      "type": "integer",
+      "example": 3,
+      "can_have_multiple_values": false,
+      "fieldname": "NumberOfHdmiports",
+      "key": "number_of_hdmiports",
+      "recommended": false,
+      "description": "The number of HDMI ports on the television or monitor"
+    },
+    "82229416d35b701d3f141174aa5f054b": {
+      "type": "string",
+      "example": "20,000:1",
+      "can_have_multiple_values": false,
+      "fieldname": "MaximumContrastRatio",
+      "key": "maximum_contrast_ratio",
+      "recommended": false,
+      "description": "The ratio between the luminance of the brightest color to that of\n        the darkest color capable of being displayed."
+    },
+    "2da53aa14b92ca922b59fdea5a6a69d6": {
+      "type": "boolean",
+      "example": "yes",
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "enum_values": ["yes", "no"],
+      "fieldname": "IsAssemblyRequired",
+      "key": "is_assembly_required",
+      "recommended": false,
+      "description": "Indicates if the product arrives unassembledand must be put together before use."
+    },
+    "6fa83aef4f8623080b9b36b3373d650f": {
+      "type": "string",
+      "example": "CCFL",
+      "can_have_multiple_values": false,
+      "fieldname": "BacklightTechnology",
+      "key": "backlight_technology",
+      "recommended": false,
+      "description": "Describes the technology used to backlight the screen or television. Commonly Cathold Fluorescent Tubes (CCFL) or Light Emitting Diodes (LED)"
+    },
+    "459473687330b5617bdaf470bcf83a7e": {
+      "type": "string",
+      "example": 5,
+      "can_have_multiple_values": false,
+      "fieldname": "AudioPowerOutput",
+      "key": "audio_power_output",
+      "recommended": false,
+      "description": "Describes the power of the audio output of the device's speakers, measured in watts."
+    },
+    "81c8727757c4fd1d1d12f5d261744c57": {
+      "type": "string",
+      "example": ["Noise Cancelling"],
+      "can_have_multiple_values": true,
+      "fieldname": "AudioFeatures",
+      "key": "audio_features",
+      "recommended": false,
+      "description": "Describes whether the product has certain special audio features."
+    },
+    "1e2de3306f34ebe0755bb8f5297f9cb0": {
+      "type": "string",
+      "example": 1.8,
+      "can_have_multiple_values": false,
+      "fieldname": "ThrowRatio",
+      "key": "throw_ratio",
+      "recommended": false,
+      "description": "The relation between the throw distance and the image width; tells\n          us what image size we can project from a certain distance away."
+    },
+    "755632f8c8070139f1d7b1d8817eeac3": {
+      "type": "string",
+      "example": 6500,
+      "can_have_multiple_values": false,
+      "fieldname": "LampLife",
+      "key": "lamp_life",
+      "recommended": false,
+      "description": "The expected life of the projection lamp in hours."
+    },
+    "697539305c05f8a9a0fe6e97e2eab4d0": {
+      "type": "string",
+      "example": 2000,
+      "can_have_multiple_values": false,
+      "fieldname": "Brightness",
+      "key": "brightness",
+      "recommended": false,
+      "description": "Brightness per bulb measured in lumens."
+    },
+    "fba4b5b5f790c6348fabe6c10d0f8bf6": {
+      "type": "string",
+      "example": "Xbox 360",
+      "can_have_multiple_values": false,
+      "fieldname": "VideoGamePlatform",
+      "key": "video_game_platform",
+      "recommended": true,
+      "description": "Describes the type of platform on which video game software is capable of running."
+    },
+    "01691d8e5b9ed5a58a109dc90b74f439": {
+      "type": "string",
+      "example": "Fallout",
+      "can_have_multiple_values": false,
+      "fieldname": "VideoGameSeries",
+      "key": "video_game_series",
+      "recommended": false,
+      "description": "The name of the video game series this game belongs to."
+    },
+    "ecb8b647ae87edddac43b94a3093e72c": {
+      "type": "string",
+      "example": "E - Everyone",
+      "can_have_multiple_values": false,
+      "fieldname": "VideoGameRating",
+      "key": "video_game_rating",
+      "recommended": false,
+      "description": "Describes the standard rating of the content of the video game. Can be important for violent games or games intended only for mature audiences."
+    },
+    "532c713f0d2a4408702814f32c02020f": {
+      "type": "string",
+      "example": "Shooter",
+      "can_have_multiple_values": false,
+      "fieldname": "VideoGameGenre",
+      "key": "video_game_genre",
+      "recommended": false,
+      "description": "Describes the genre, style or type of video game being sold."
+    },
+    "e65585ff17b284d24ee18e28851f6ac8": {
+      "type": "measurement",
+      "example": "1 TB",
+      "enum_values": ["KB", "MB", "GB", "TB"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "StorageCapacity",
+      "key": "storage_capacity",
+      "recommended": false,
+      "description": "Describes the amount of storage space on the item's hard drive, typically measured in megabytes, gigabytes or terabytes."
+    },
+    "9a9c97dfb6df9491e73d4ba7d39e2460": {
+      "type": "string",
+      "example": ["Kinect"],
+      "can_have_multiple_values": true,
+      "fieldname": "RequiredPeripherals",
+      "key": "required_peripherals",
+      "recommended": false,
+      "description": "Indicates any type of required accessory or peripheral necessary to operate the item (or play the video game)."
+    },
+    "a36f46f58ba3a8907408d6c24e50bfad": {
+      "type": "string",
+      "example": "09-19-2019",
+      "can_have_multiple_values": false,
+      "fieldname": "ReleaseDate",
+      "key": "release_date",
+      "recommended": false,
+      "description": "Describes the specific date which marks when the product was made available for public distribution, provided in the format MM-DD-YYYY"
+    },
+    "48504b28464be452dc971f271b0eef35": {
+      "type": "string",
+      "example": "CD",
+      "can_have_multiple_values": false,
+      "fieldname": "PhysicalMediaFormat",
+      "key": "physical_media_format",
+      "recommended": false,
+      "description": "Describes the standard media format in which the product exists."
+    },
+    "95f1c14e6ac4218a6af57710a935fb6f": {
+      "type": "string",
+      "example": "Android",
+      "can_have_multiple_values": false,
+      "fieldname": "OperatingSystem",
+      "key": "operating_system",
+      "recommended": false,
+      "description": "Describes the type of preloaded operating system software installed on the device."
+    },
+    "87ee129e6abae679ef3dc1881c29ac4c": {
+      "type": "string",
+      "example": "Natural/Unfinished",
+      "can_have_multiple_values": false,
+      "fieldname": "Finish",
+      "key": "finish",
+      "recommended": true,
+      "description": "The external treatment to the productthat usually includes a change inappearance or texture to the item.Commonly used for furniture includewood, metal and fabric."
+    },
+    "73c8639362fab24e43a3fa21a122d3f6": {
+      "type": "string",
+      "example": "Bohemian",
+      "can_have_multiple_values": false,
+      "fieldname": "DecorStyle",
+      "key": "decor_style",
+      "recommended": true,
+      "description": "The decorative style in which the product was made."
+    },
+    "9c05349004f01b710d863a5bcc135754": {
+      "type": "string",
+      "example": ["Designer"],
+      "can_have_multiple_values": true,
+      "fieldname": "AdditionalFeatures",
+      "key": "additional_features",
+      "recommended": false,
+      "description": "Additional features related to your item that might be important for buyers."
+    },
+    "447e1ca997ac7372d84321a5da8b9577": {
+      "type": "string",
+      "example": ["Family Room"],
+      "can_have_multiple_values": true,
+      "fieldname": "RecommendedRooms",
+      "key": "recommended_rooms",
+      "recommended": false,
+      "description": "The rooms where the item is likely or recommended to be used."
+    },
+    "cb8a3c1875a379537c185708e6662ba6": {
+      "type": "measurement",
+      "example": "20 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "SeatBackHeight",
+      "key": "seat_back_height",
+      "recommended": false,
+      "description": "Indicates the seat back height from the base of the seat to the top of the back. This may be separate from the \"Assembled Product Height\" and \"Seat Height\" attributes."
+    },
+    "ed80e4f1f84fcb9b076e9089aa9b73da": {
+      "type": "measurement",
+      "example": "36 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "SeatHeight",
+      "key": "seat_height",
+      "recommended": false,
+      "description": "Indicates height from the floor to the top of the seat. This may be separate from the \"Assembled Product Height\" and \"Seat Back Height\" attributes."
+    },
+    "eaf4eb99a4c71f786c74f207839181ab": {
+      "type": "string",
+      "example": "Leather",
+      "can_have_multiple_values": false,
+      "fieldname": "SeatMaterial",
+      "key": "seat_material",
+      "recommended": false,
+      "description": "The material of the item's seat cushion. This may be separate from the item's main material composition, which falls under the \"Material\" attribute."
+    },
+    "f2d839922ab1a15c3720eb42f01393ff": {
+      "type": "string",
+      "example": "Square",
+      "can_have_multiple_values": false,
+      "fieldname": "Shape",
+      "key": "shape",
+      "recommended": false,
+      "description": "The general shape of the product. Often used to describe\n        furniture and home furnishings."
+    },
+    "00d4ef3a1bb967e59e960f07a8a36010": {
+      "type": "enum",
+      "example": ["Antique"],
+      "can_have_multiple_values": true,
+      "enum_values": [
+        "Foldable",
+        "Inflatable",
+        "Pump Included",
+        "Wheeled",
+        "Antique"
+      ],
+      "can_have_unknown_value": false,
+      "fieldname": "StandardFeatures",
+      "key": "standard_features",
+      "recommended": false,
+      "description": "Standard features related to your item that might be important for buyers."
+    },
+    "2733dc5d8c97d75657a86568037a0609": {
+      "type": "integer",
+      "example": 4,
+      "can_have_multiple_values": false,
+      "fieldname": "NumberOfDrawers",
+      "key": "number_of_drawers",
+      "recommended": false,
+      "description": "The number of drawers included in the product."
+    },
+    "9e1903c5cd2876e1c9889eb5cea8045a": {
+      "type": "integer",
+      "example": 4,
+      "can_have_multiple_values": false,
+      "fieldname": "NumberOfShelves",
+      "key": "number_of_shelves",
+      "recommended": false,
+      "description": "The number of shelves included in the product."
+    },
+    "8cafc76619e3f64c83abec41a95b9915": {
+      "type": "string",
+      "example": "Wall Mount",
+      "can_have_multiple_values": false,
+      "fieldname": "MountType",
+      "key": "mount_type",
+      "recommended": false,
+      "description": "The method by which the item is attached or anchored. Used for products such as shelving and other fixtures."
+    },
+    "97bdb9242e7b2962284619b2ce7c06a4": {
+      "type": "measurement",
+      "example": "10 in",
+      "enum_values": ["mm", "cm", "m", "in", "ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "MattressThickness",
+      "key": "mattress_thickness",
+      "recommended": false,
+      "description": "The measure from the bottom of the mattress to the crown"
+    },
+    "a700f8e116174455d5d9f3782aa0bf4e": {
+      "type": "boolean",
+      "example": "yes",
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "enum_values": ["yes", "no"],
+      "fieldname": "IsPowered",
+      "key": "is_powered",
+      "recommended": false,
+      "description": "Indicates if the item uses electricity and requires a power cord or batteries to operate."
+    },
+    "7f54c0815b0e8d9cb192bdc4819bd7f5": {
+      "type": "enum",
+      "example": "Indoor Only",
+      "can_have_multiple_values": false,
+      "enum_values": ["Indoor Only", "Outdoor Only", "Indoor/Outdoor"],
+      "can_have_unknown_value": true,
+      "fieldname": "IndoororOutdoor",
+      "key": "indooror_outdoor",
+      "recommended": false,
+      "description": "Indicates if the item is indoor only, outdoor only, or intended for both."
+    },
+    "39a086121f568673a43aedb5478c26d4": {
+      "type": "string",
+      "example": "Foam",
+      "can_have_multiple_values": false,
+      "fieldname": "FillMaterial",
+      "key": "fill_material",
+      "recommended": false,
+      "description": "The material used to stuff the item usually in cushions, pillows,\n          mattresses, and bean bags."
+    },
+    "d17ad1a388d5c83e6d89a16d3ac964fb": {
+      "type": "string",
+      "example": "Extra Firm",
+      "can_have_multiple_values": false,
+      "fieldname": "ComfortLevel",
+      "key": "comfort_level",
+      "recommended": false,
+      "description": "The firmness or softness of a mattress."
+    },
+    "9d73d1c85fae03275869c6806d30fd93": {
+      "type": "string",
+      "example": "Canopy Bed",
+      "can_have_multiple_values": false,
+      "fieldname": "BedFrameType",
+      "key": "bed_frame_type",
+      "recommended": false,
+      "description": "The type or style of the bed. Does not include Futons, Day Beds, or Sleepers."
+    },
+    "7d8fefe9bf9918c271f908a0e83f5f16": {
+      "type": "enum",
+      "example": ["Wheeled"],
+      "can_have_multiple_values": true,
+      "enum_values": ["Foldable", "Wheeled", "Antique"],
+      "can_have_unknown_value": false,
+      "fieldname": "StandardFeatures",
+      "key": "standard_features",
+      "recommended": false,
+      "description": "Standard features related to your item that might be important for buyers."
+    },
+    "e009f02a406e7aab29c5ab8230d08848": {
+      "type": "string",
+      "example": "Natural/Unfinished",
+      "can_have_multiple_values": false,
+      "fieldname": "Finish",
+      "key": "finish",
+      "recommended": false,
+      "description": "The external treatment to the productthat usually includes a change inappearance or texture to the item.Commonly used for furniture includewood, metal and fabric."
+    },
+    "13828083302ba311fdebc396a1610bf6": {
+      "type": "string",
+      "example": ["Fever"],
+      "can_have_multiple_values": true,
+      "fieldname": "HealthConcern",
+      "key": "health_concern",
+      "recommended": true,
+      "description": "Indicates if the item is meant to alleviate particular health issues, illnesses or life stages. For concerns specific to skin care, please use the Skin Care Concern attribute."
+    },
+    "11f3261c7ccebb79e06751f778d5d4ab": {
+      "type": "measurement",
+      "example": "12 oz",
+      "enum_values": ["ml", "l", "oz", "cu_ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "Capacity",
+      "key": "capacity",
+      "recommended": true,
+      "description": "Indicates the capacity or volume of your item. This is important for buyers to know the amount of product they are receiving and is important for skin care, beauty & hair care products."
+    },
+    "2d80b0c58142a82357f2d2fdfafd9068": {
+      "type": "string",
+      "example": ["Beeswax"],
+      "can_have_multiple_values": true,
+      "fieldname": "Ingredients",
+      "key": "ingredients",
+      "recommended": true,
+      "description": "The list of all ingredients contained in an item, as found on the product label mandated by FDA guidelines."
+    },
+    "365ecf662d48185b92a5aa253d935173": {
+      "type": "string",
+      "example": "3 to 5 hours",
+      "can_have_multiple_values": false,
+      "fieldname": "ResultTime",
+      "key": "result_time",
+      "recommended": false,
+      "description": "Duration of time necessary to see the outcome from using a product. Typically used for medical and personal care test kits and monitors."
+    },
+    "7699774215529bc8717eb00ce738c58a": {
+      "type": "string",
+      "example": "Heavy",
+      "can_have_multiple_values": false,
+      "fieldname": "Absorbency",
+      "key": "absorbency",
+      "recommended": false,
+      "description": "Term describing the ability of a product to absorb moisture. Used in personal care products such as pads and liners."
+    },
+    "2639fc784370fb97d9a426b33e6eff0e": {
+      "type": "measurement",
+      "example": "0.4 ml",
+      "enum_values": ["ml", "l", "oz", "cu_ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "ServingSize",
+      "key": "serving_size",
+      "recommended": false,
+      "description": "Measurement value specifying the amount of the item typically used as a reference on the label of that item to list per serving information (nutrients, calories, total fat). Applicable for a wide variety of products including food, beverages, and nutritional supplements."
+    },
+    "336df2b3fca4bc8318f7589b8c888d03": {
+      "type": "string",
+      "example": ["Dry Skin"],
+      "can_have_multiple_values": true,
+      "fieldname": "SkinCareConcern",
+      "key": "skin_care_concern",
+      "recommended": false,
+      "description": "Indicates if the item is meant to alleviate particular skin care issues. For general health concerns like obesity, or blood pressure please use the Health Concerns attribute. Values may be similar to the Skin Type attribute - \"dry cracked skin\" may be a cocnern but \"dry\" is a skin type."
+    },
+    "eba9b3d21340c3ed25d6778417988888": {
+      "type": "enum",
+      "example": "Oily",
+      "can_have_multiple_values": false,
+      "enum_values": ["Oily", "Dry", "Combination", "Sensitive"],
+      "can_have_unknown_value": true,
+      "fieldname": "SkinType",
+      "key": "skin_type",
+      "recommended": false,
+      "description": "Indicates the general skin type that the product is intended for on the oily/dry spectrum."
+    },
+    "cffbfe91501fcda43b326b2797a39ee0": {
+      "type": "integer",
+      "example": 15,
+      "can_have_multiple_values": false,
+      "fieldname": "SpfValue",
+      "key": "spf_value",
+      "recommended": false,
+      "description": "Indicates the strength of SPF (Sun Protection Factor) in an item. This describes how well the product can block out harmful rays from the run. Commonly found in suncreen and makeup products."
+    },
+    "4f2642a8dcd42338499b2aa75ffca1fe": {
+      "type": "enum",
+      "example": ["Reusable"],
+      "can_have_multiple_values": true,
+      "enum_values": [
+        "Adaptive Lenses",
+        "Automatic Shut Off",
+        "Cordless",
+        "Foldable",
+        "Industrial",
+        "Latex-Free",
+        "Non-Comedogenic",
+        "Portable",
+        "Polarized",
+        "Reusable",
+        "Self-Tanning",
+        "Tinted",
+        "Travel Size",
+        "Waterproof",
+        "Wheeled",
+        "Scratch-Resistant"
+      ],
+      "can_have_unknown_value": false,
+      "fieldname": "StandardFeatures",
+      "key": "standard_features",
+      "recommended": false,
+      "description": "Standard features related to your item that might be important for buyers."
+    },
+    "78aba0a00b3412827370aede724962dc": {
+      "type": "string",
+      "example": ["Plastic"],
+      "can_have_multiple_values": true,
+      "fieldname": "LensMaterial",
+      "key": "lens_material",
+      "recommended": false,
+      "description": "The substances an optical lens is made out of."
+    },
+    "e6041e1b82f9e3ac106d984107d13504": {
+      "type": "string",
+      "example": "Single Vision",
+      "can_have_multiple_values": false,
+      "fieldname": "LensType",
+      "key": "lens_type",
+      "recommended": false,
+      "description": "Whether the lens is single, multifocal, or tinted"
+    },
+    "937f3f40d16b2b5a23052e2d7311c6ff": {
+      "type": "string",
+      "example": "Blue",
+      "can_have_multiple_values": false,
+      "fieldname": "LensTint",
+      "key": "lens_tint",
+      "recommended": false,
+      "description": "Color of lens tint."
+    },
+    "8b4897149a7b0cf1c4b79f6ca7c03881": {
+      "type": "string",
+      "example": ["Solid"],
+      "can_have_multiple_values": true,
+      "fieldname": "Keywords",
+      "key": "keywords",
+      "recommended": false,
+      "description": "Keywords that might be used to search for this term, including synonyms and related terms."
+    },
+    "830b557ebbb8f05aa8d8e89c8073c9d8": {
+      "type": "string",
+      "example": [
+        { "name": "Pyrithione zinc", "amount": 2.5 },
+        { "name": "Salicylic Acid", "amount": 2 }
+      ],
+      "can_have_multiple_values": false,
+      "fieldname": "IngredientsComposition",
+      "key": "ingredients_composition",
+      "recommended": false,
+      "description": "The ingredients with the corresponding composition value"
+    },
+    "45f47b75dfc8dcab7bcc1b6895c572a0": {
+      "type": "string",
+      "example": ["Iron Oxide"],
+      "can_have_multiple_values": true,
+      "fieldname": "InactiveIngredients",
+      "key": "inactive_ingredients",
+      "recommended": false,
+      "description": "Describes the list of inactive ingredients as shown on the item label."
+    },
+    "a416c6be2906ac2830fbd812fba3e591": {
+      "type": "enum",
+      "example": "Full-Rim",
+      "can_have_multiple_values": false,
+      "enum_values": ["Full-Rim", "Rimless", "Semi-Rimless", "Half-Rim"],
+      "can_have_unknown_value": true,
+      "fieldname": "EyewearRim",
+      "key": "eyewear_rim",
+      "recommended": false,
+      "description": "Whether eyewear has rims, partial rims, or no rim at all."
+    },
+    "f4b8e7636597b2b532f6c75c8bd2a7a9": {
+      "type": "string",
+      "example": ["1 teaspoon every 6 hours"],
+      "can_have_multiple_values": true,
+      "fieldname": "Dosage",
+      "key": "dosage",
+      "recommended": false,
+      "description": "The amount of a medication, drug, or supplement that is directed to be taken, or applied at one time or regularly during a period of time, as specified by the manufacturer."
+    },
+    "91455c53f237eb64c3de88f2c35b9556": {
+      "type": "string",
+      "example": ["Eyes", "Face"],
+      "can_have_multiple_values": true,
+      "fieldname": "BodyPart",
+      "key": "body_part",
+      "recommended": false,
+      "description": "Describes the particular body part(s) for which the item is intended."
+    },
+    "007e22a1352c2d2a1a443ba90e14b127": {
+      "type": "boolean",
+      "example": "yes",
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "enum_values": ["yes", "no"],
+      "fieldname": "BatteriesRequired",
+      "key": "batteries_required",
+      "recommended": false,
+      "description": "Indicates if batteries are required to use the product."
+    },
+    "052d7ff877183c9dcce5362a73e73428": {
+      "type": "integer",
+      "example": 400,
+      "can_have_multiple_values": false,
+      "fieldname": "UVRating",
+      "key": "u_v_rating",
+      "recommended": false,
+      "description": "Ultraviolet rating for eyewear."
+    },
+    "3308f187f85aeefe4d6ed8fc5cd8e8e6": {
+      "type": "enum",
+      "example": "Fair",
+      "can_have_multiple_values": false,
+      "enum_values": ["Fair", "Light", "Medium", "Neutral", "Olive", "Dark"],
+      "can_have_unknown_value": true,
+      "fieldname": "SkinTone",
+      "key": "skin_tone",
+      "recommended": false,
+      "description": "Describes the color or shade of skin that a product is targeted for. This is separate from Color Name of the product. \"Olive\" may be a color name from the manufacturer as well as the type of skin tone the product is targeting."
+    },
+    "9a04dccec14d02d689cf02fb757d1a10": {
+      "type": "string",
+      "example": ["Beeswax"],
+      "can_have_multiple_values": true,
+      "fieldname": "InactiveIngredients",
+      "key": "inactive_ingredients",
+      "recommended": false,
+      "description": "Describes the list of inactive ingredients as shown on the item label."
+    },
+    "896fe12fa920abf8d338cef50e162628": {
+      "type": "string",
+      "example": ["Fever"],
+      "can_have_multiple_values": true,
+      "fieldname": "HealthConcern",
+      "key": "health_concern",
+      "recommended": false,
+      "description": "Indicates if the item is meant to alleviate particular health issues, illnesses or life stages. For concerns specific to skin care, please use the Skin Care Concern attribute."
+    },
+    "3456eaf701f7278c2be139c78bcabd3f": {
+      "type": "enum",
+      "example": ["Coarse"],
+      "can_have_multiple_values": true,
+      "enum_values": [
+        "Coarse",
+        "Color Treated",
+        "Curly",
+        "Damaged",
+        "Dry",
+        "Fine",
+        "Oily"
+      ],
+      "can_have_unknown_value": false,
+      "fieldname": "HairType",
+      "key": "hair_type",
+      "recommended": false,
+      "description": "Indicates the general hair types that the product is intended for relating to texture, coarseness, oiliness, thickness, and curliness."
+    },
+    "ce6ffae63aa69791f8881e7fb7c2bea8": {
+      "type": "string",
+      "example": ["Wash with warm water & soap"],
+      "can_have_multiple_values": true,
+      "fieldname": "CareInstructions",
+      "key": "care_instructions",
+      "recommended": false,
+      "description": "Describes how the item should be cleaned, cared for or maintained."
+    },
+    "f7cdf1aaddb5d5cf96bdc35a3f9ba7c7": {
+      "type": "string",
+      "example": "100% Hand-Tied",
+      "can_have_multiple_values": false,
+      "fieldname": "WigCapType",
+      "key": "wig_cap_type",
+      "recommended": false,
+      "description": "The construction style of the wig cap (also called the \"wig base\"), affecting the wig's appearance, durability, and styling options."
+    },
+    "16f4737bd60328d18f404968ba09f5de": {
+      "type": "enum",
+      "example": ["Automatic Shut Off"],
+      "can_have_multiple_values": true,
+      "enum_values": ["Automatic Shut Off", "Energy Star-Certified"],
+      "can_have_unknown_value": false,
+      "fieldname": "StandardFeatures",
+      "key": "standard_features",
+      "recommended": false,
+      "description": "Standard features related to your item that might be important for buyers."
+    },
+    "ecb45e77061f56ea0bf5ab6280fd7b6d": {
+      "type": "integer",
+      "example": 1,
+      "can_have_multiple_values": false,
+      "fieldname": "NumberofLights",
+      "key": "numberof_lights",
+      "recommended": false,
+      "description": "The number of lights or bulbs contained within a light or light fixture."
+    },
+    "884e05ecb296a36e8e63b1b2bd060fb9": {
+      "type": "string",
+      "example": "Fluorescent",
+      "can_have_multiple_values": false,
+      "fieldname": "LightBulbType",
+      "key": "light_bulb_type",
+      "recommended": false,
+      "description": "The type of light bulb."
+    },
+    "0e8054ce0f52ba0d4105f9da4cbfcbfe": {
+      "type": "measurement",
+      "example": "12 oz",
+      "enum_values": ["ml", "l", "oz", "cu_ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "Capacity",
+      "key": "capacity",
+      "recommended": false,
+      "description": "Indicates the maximum amount that the item can hold like pounds, liters or volume. Does not include Storage Capacity which is used for digital items."
+    },
+    "64b3fe664fa4c3666faae8b77a734631": {
+      "type": "measurement",
+      "example": "12 oz",
+      "enum_values": ["ml", "l", "oz", "cu_ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "Capacity",
+      "key": "capacity",
+      "recommended": true,
+      "description": "Indicates the maximum amount that the item can hold like pounds, liters or volume. Does not include Storage Capacity which is used for digital items."
+    },
+    "7c421b8f435ae90ca36f71389bd6b9ca": {
+      "type": "measurement",
+      "example": "10 g",
+      "enum_values": ["mg", "g", "kg", "oz", "lb"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "ProductWeight",
+      "key": "product_weight",
+      "recommended": true,
+      "description": "The weight of the fully assembled product."
+    },
+    "3eb15df7a5722992f9aa3dbf1a8c3923": {
+      "type": "string",
+      "example": ["Low Noise"],
+      "can_have_multiple_values": true,
+      "fieldname": "AdditionalFeatures",
+      "key": "additional_features",
+      "recommended": false,
+      "description": "Additional features related to your item that might be important for buyers."
+    },
+    "049be88f7223ae9a349f4d47ec511389": {
+      "type": "measurement",
+      "example": "220 V",
+      "enum_values": ["V", "KV"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "Volts",
+      "key": "volts",
+      "recommended": false,
+      "description": "The number of volts the product produces or requires. Also known as Voltage;"
+    },
+    "3aa26481e6a2737040dacf5844ff32f2": {
+      "type": "enum",
+      "example": ["Automatic Shut Off"],
+      "can_have_multiple_values": true,
+      "enum_values": [
+        "Automatic Shut Off",
+        "Energy Star-Certified",
+        "Bluetooth Compatible",
+        "Industrial",
+        "Remote Control Included",
+        "Wi-Fi Compatible"
+      ],
+      "can_have_unknown_value": false,
+      "fieldname": "StandardFeatures",
+      "key": "standard_features",
+      "recommended": false,
+      "description": "Standard features related to your item that might be important for buyers."
+    },
+    "1b4aabae8670a6b5f8ad83a12c664b37": {
+      "type": "string",
+      "example": 44,
+      "can_have_multiple_values": false,
+      "fieldname": "SoundRating",
+      "key": "sound_rating",
+      "recommended": false,
+      "description": "The sound decibel rating for the noise level of the appliance."
+    },
+    "43e44c783f17bdfc8772466174badee1": {
+      "type": "string",
+      "example": ["Amazon Alexa"],
+      "can_have_multiple_values": true,
+      "fieldname": "SmartHomeCompatibility",
+      "key": "smart_home_compatibility",
+      "recommended": false,
+      "description": "The type of Smart Home devices that the product is compatible with."
+    },
+    "140a15b94c6d50aa103b176dc71951ff": {
+      "type": "integer",
+      "example": 2,
+      "can_have_multiple_values": false,
+      "fieldname": "NumberofDoors",
+      "key": "numberof_doors",
+      "recommended": false,
+      "description": "The number of doors on the item."
+    },
+    "454fe2a0cbc9e12c03b9db3ccfe98a21": {
+      "type": "integer",
+      "example": 4,
+      "can_have_multiple_values": false,
+      "fieldname": "NumberofBurners",
+      "key": "numberof_burners",
+      "recommended": false,
+      "description": "The number of cooking burners or elements."
+    },
+    "b771092e645e5a68eb3c34f590d4a028": {
+      "type": "string",
+      "example": "Top Load",
+      "can_have_multiple_values": false,
+      "fieldname": "LoadPosition",
+      "key": "load_position",
+      "recommended": false,
+      "description": "The type of load position for washers & dryers."
+    },
+    "da1ff3922c1b46224c541ecf62c91f69": {
+      "type": "boolean",
+      "example": "yes",
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "enum_values": ["yes", "no"],
+      "fieldname": "IsSet",
+      "key": "is_set",
+      "recommended": false,
+      "description": "Indicates if the product is being sold as a set, like washer & dryer set."
+    },
+    "424a3c305eb21ffbd1257294397cc022": {
+      "type": "string",
+      "example": "Electric",
+      "can_have_multiple_values": false,
+      "fieldname": "FuelType",
+      "key": "fuel_type",
+      "recommended": false,
+      "description": "The type of fuel used to power certain appliances."
+    },
+    "96481ec4bdef8e6fe8e5093ef39a68d0": {
+      "type": "integer",
+      "example": 10200,
+      "can_have_multiple_values": false,
+      "fieldname": "BTU",
+      "key": "b_t_u",
+      "recommended": false,
+      "description": "The number of British Thermal Units for heating and cooling appliances."
+    },
+    "608d8c80b0c29120dd74b33b92b656f3": {
+      "type": "measurement",
+      "example": "400 W",
+      "enum_values": ["W", "KW", "MW", "GW"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "Watts",
+      "key": "watts",
+      "recommended": false,
+      "description": "The number of watts the product procues or requires. Also known as Wattage."
+    },
+    "8f4a7d7221541f65cac8a79c08758bfb": {
+      "type": "string",
+      "example": "Oil",
+      "can_have_multiple_values": false,
+      "fieldname": "ProductForm",
+      "key": "product_form",
+      "recommended": true,
+      "description": "The consistency, texture or formulation of the item and the way\n          it will be consumed or dispensed."
+    },
+    "803d2a584a08f5944b306958fdb95a21": {
+      "type": "string",
+      "example": ["Vanilla"],
+      "can_have_multiple_values": true,
+      "fieldname": "Scent",
+      "key": "scent",
+      "recommended": true,
+      "description": "The scent or fragrance of your item; including items\n        labelled as \"unscented\""
+    },
+    "4e7d7d90f4137c48ce55a4b9a823eff2": {
+      "type": "string",
+      "example": ["some_string", "other"],
+      "can_have_multiple_values": true,
+      "fieldname": "Ingredients",
+      "key": "ingredients",
+      "recommended": true,
+      "description": "The list of all ingredients contained in an item, as found on the product label mandated by FDA guidelines."
+    },
+    "c8d76e2396b1577c1c9da0d9ec4cf770": {
+      "type": "string",
+      "example": ["Carpet"],
+      "can_have_multiple_values": true,
+      "fieldname": "RecommendedUse",
+      "key": "recommended_use",
+      "recommended": true,
+      "description": "The recommended use/surface of cleaning product."
+    },
+    "ec65783a5d3d73c90f83a5d59797ac73": {
+      "type": "string",
+      "example": ["Unscented"],
+      "can_have_multiple_values": true,
+      "fieldname": "AdditionalFeatures",
+      "key": "additional_features",
+      "recommended": false,
+      "description": "Additional features related to your item that might be important for buyers."
+    },
+    "febfed4ca6efd5a645a1862390468384": {
+      "type": "string",
+      "example": "Canister",
+      "can_have_multiple_values": false,
+      "fieldname": "VacuumType",
+      "key": "vacuum_type",
+      "recommended": false,
+      "description": "The type of vacuum cleaner."
+    },
+    "da6b491d82e229483b578dec94e4ff95": {
+      "type": "enum",
+      "example": ["Biodegradable"],
+      "can_have_multiple_values": true,
+      "enum_values": ["Biodegradable", "Recyclable"],
+      "can_have_unknown_value": false,
+      "fieldname": "StandardFeatures",
+      "key": "standard_features",
+      "recommended": false,
+      "description": "Standard features related to your item that might be important for buyers."
+    },
+    "6cc94d5bc1810a51cf9b3139b629fd37": {
+      "type": "integer",
+      "example": 15,
+      "can_have_multiple_values": false,
+      "fieldname": "ShelfLife",
+      "key": "shelf_life",
+      "recommended": false,
+      "description": "The length of time that the product can be stored without spoiling or losing quality, measured in days."
+    },
+    "23a063f0e0a0a294b129169b749639fa": {
+      "type": "measurement",
+      "example": "12 oz",
+      "enum_values": ["ml", "l", "oz", "cu_ft"],
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "fieldname": "Capacity",
+      "key": "capacity",
+      "recommended": false,
+      "description": "Indicates the maximum amount that the item can hold like pounds, liters or volume."
+    },
+    "b9bee7f2bace5f8065911d6998b34bad": {
+      "type": "string",
+      "example": "Bag",
+      "can_have_multiple_values": false,
+      "fieldname": "BagType",
+      "key": "bag_type",
+      "recommended": false,
+      "description": "Indicates whether the vacuum cleaner is bag or bagless."
+    },
+    "07360c7815892f05de28ec9f92926612": {
+      "type": "enum",
+      "example": ["Chemical"],
+      "can_have_multiple_values": true,
+      "enum_values": ["Chemical", "Combustible", "Flammable"],
+      "can_have_unknown_value": false,
+      "fieldname": "Warnings",
+      "key": "warnings",
+      "recommended": false,
+      "description": "Warnings associated with the product."
+    },
+    "e6c000a4a5c024e4385c9e89ef1232c3": {
+      "type": "integer",
+      "example": 400,
+      "can_have_multiple_values": false,
+      "fieldname": "ThreadCount",
+      "key": "thread_count",
+      "recommended": true,
+      "description": "The number of threads per square inch of fabric."
+    },
+    "2410d57d61f0e552896d9aca00f7b67b": {
+      "type": "enum",
+      "example": ["Water Resistant"],
+      "can_have_multiple_values": true,
+      "enum_values": [
+        "Reversible",
+        "Hypoallergenic",
+        "Stain Resistant",
+        "Water Resistant",
+        "Organic",
+        "Sustainably Sourced"
+      ],
+      "can_have_unknown_value": false,
+      "fieldname": "StandardFeatures",
+      "key": "standard_features",
+      "recommended": false,
+      "description": "Standard features related to your item that might be important for buyers."
+    },
+    "c1a740062d17b6704080705c2474435c": {
+      "type": "integer",
+      "example": 3,
+      "can_have_multiple_values": false,
+      "fieldname": "PiecesInSet",
+      "key": "pieces_in_set",
+      "recommended": false,
+      "description": "The number of items included in the set. If the item contains matching fitted sheets, flat sheets, and 2 pillowcases - the number is 4."
+    },
+    "0f4c1a53965b293c894d4b0e607b9770": {
+      "type": "string",
+      "example": ["Designer", "Anti-Streak"],
+      "can_have_multiple_values": true,
+      "fieldname": "AdditionalFeatures",
+      "key": "additional_features",
+      "recommended": false,
+      "description": "Additional features related to your item that might be important for buyers."
+    },
+    "4a6f34f51dbacff4a7033c14e600ce06": {
+      "type": "boolean",
+      "example": "yes",
+      "can_have_multiple_values": false,
+      "can_have_unknown_value": false,
+      "enum_values": ["yes", "no"],
+      "fieldname": "IsSet",
+      "key": "is_set",
+      "recommended": false,
+      "description": "Indicates if the product contains 2 of more different items that are sold as part of a set."
+    },
+    "e8e50abdc6b50b497e7c90af199feeec": {
+      "type": "integer",
+      "example": 1,
+      "can_have_multiple_values": false,
+      "fieldname": "NumberOfLicenses",
+      "key": "number_of_licenses",
+      "recommended": true,
+      "description": "The maximum number of users or installations allowed under the terms of the software licensing agreement."
+    },
+    "9c3c05234da77307c8b4fc50977ca324": {
+      "type": "string",
+      "example": ["Windows 7 or later"],
+      "can_have_multiple_values": true,
+      "fieldname": "SoftwareSystemRequirements",
+      "key": "software_system_requirements",
+      "recommended": true,
+      "description": "The basic requirements necessary of any system in order to satisfactorily run the software."
+    },
+    "46c833eff8474794a70b21f9d2389e04": {
+      "type": "string",
+      "example": "Antivirus & Security",
+      "can_have_multiple_values": false,
+      "fieldname": "SoftwareCategory",
+      "key": "software_category",
+      "recommended": false,
+      "description": "The general category of software to which the item is most closely associated with"
+    },
+    "1c4ef2904cadfca2cf53773ad85ce53d": {
+      "type": "string",
+      "example": "7.2",
+      "can_have_multiple_values": false,
+      "fieldname": "SoftwareVersion",
+      "key": "software_version",
+      "recommended": false,
+      "description": "The version number assigned to this specific release of the software."
+    }
+  }

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -868,6 +868,14 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_IMAGE ] ) ) {
 			$woo_product->set_product_image( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_IMAGE ] ) ) );
 		}
+
+		if ( isset( $_POST[ WC_Facebook_Product::FB_BRAND ] ) ) {
+			$woo_product->set_fb_brand( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_BRAND ] ) ) );
+		}
+
+		if ( isset( $_POST[ WC_Facebook_Product::FB_MPN ] ) ) {
+			$woo_product->set_fb_mpn( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_MPN ] ) ) );
+		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 	}
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1270,6 +1270,24 @@ class Admin {
 					)
 				);
 
+				woocommerce_wp_text_input(
+					array(
+						'id'    => \WC_Facebook_Product::FB_BRAND,
+						'label' => __( 'Brand', 'facebook-for-woocommerce' ),
+						'value' => $fb_brand,
+						'class' => 'enable-if-sync-enabled',
+					)
+				);
+
+				woocommerce_wp_text_input(
+					array(
+						'id'    => \WC_Facebook_Product::FB_MPN,
+						'label' => __( 'Manufacturer Parts Number (MPN)', 'facebook-for-woocommerce' ),
+						'value' => $fb_mpn,
+						'class' => 'enable-if-sync-enabled',
+					)
+				);
+
 				woocommerce_wp_hidden_input(
 					array(
 						'id'    => \WC_Facebook_Product::FB_REMOVE_FROM_SYNC,

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -47,7 +47,7 @@ class Enhanced_Catalog_Attribute_Fields {
 	 */
 	private $category_handler;
 
-	public function __construct( $page_type, \WP_Term $term = null, \WC_Product $product = null ) {
+	public function __construct( $page_type, ?\WP_Term $term = null, ?\WC_Product $product = null ) {
 		$this->page_type        = $page_type;
 		$this->term             = $term;
 		$this->product          = $product;

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -944,7 +944,11 @@ class WC_Facebook_Product {
 		$matched_attributes = array_filter(
 			$all_attributes,
 			function( $attribute ) use ( $sanitized_keys ) {
-				return in_array( $attribute['key'], $sanitized_keys );
+				// Check if $attribute is an array and has the 'key' index
+				if (is_array($attribute) && isset($attribute['key'])) {
+					return in_array($attribute['key'], $sanitized_keys);
+				}
+				return false; // Return false if $attribute is not valid
 			}
 		);
 
@@ -979,6 +983,11 @@ class WC_Facebook_Product {
 		// Loop through variants (size, color, etc) if they exist
 		// For each product field type, pull the single variant
 		foreach ( $variant_names as $original_variant_name ) {
+
+			// Ensure that the attribute exists before accessing it
+			if ( ! isset( $attributes[ $original_variant_name ] ) ) {
+				continue; // Skip if the attribute is not set
+			}
 
 			// don't handle any attributes that are designated as Commerce attributes
 			if ( in_array( str_replace( 'attribute_', '', strtolower( $original_variant_name ) ), Products::get_distinct_product_attributes( $this->woo_product ), true ) ) {

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -360,4 +360,83 @@ class fbproductTest extends WP_UnitTestCase {
 
 		$this->assertEquals(isset($data['gtin']), false);
 	}
+
+	/**
+	 * Test Brand is added for simple product 
+	 * @return void
+	 */
+	public function test_brand_for_simple_product_set() {
+		$woo_product = WC_Helper_Product::create_simple_product();
+		$facebook_product = new \WC_Facebook_Product( $woo_product );
+		$facebook_product->set_fb_brand('Nike');
+		$facebook_product->save();
+
+		$fb_product = new \WC_Facebook_Product( $woo_product );
+		$data = $fb_product->prepare_product();
+
+		$this->assertEquals( $data['brand'], 'Nike' );
+	}
+
+	/**
+	 * Test MPN is added for simple product 
+	 * @return void
+	 */
+	public function test_mpn_for_simple_product_set() {
+		$woo_product = WC_Helper_Product::create_simple_product();
+		$facebook_product = new \WC_Facebook_Product( $woo_product );
+		$facebook_product->set_fb_mpn('123456789');
+		$facebook_product->save();
+
+		$fb_product = new \WC_Facebook_Product( $woo_product );
+		$data = $fb_product->prepare_product();
+
+		$this->assertEquals( $data['mpn'], '123456789' );
+	}
+
+	/**
+	 * Test MPN is added for variable product 
+	 * @return void
+	 */
+	public function test_mpn_for_variable_product_set() {
+		$woo_product = WC_Helper_Product::create_variation_product();
+		$woo_variation = wc_get_product($woo_product->get_children()[0]);
+		$facebook_product = new \WC_Facebook_Product( $woo_variation, new \WC_Facebook_Product( $woo_product ) );
+		$facebook_product->set_fb_mpn('987654321');
+		$facebook_product->save();
+
+		$fb_product = new \WC_Facebook_Product( $woo_variation, new \WC_Facebook_Product( $woo_product ) );
+		$data = $fb_product->prepare_product();
+
+		$this->assertEquals( $data['mpn'], '987654321' );
+	}
+
+	/**
+	 * Test it gets brand from parent product if it is a variation.
+	 * @return void
+	 */
+	public function test_get_fb_brand_variable_products() {
+		// Create a variable product and set the brand for the parent
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$facebook_product_parent = new \WC_Facebook_Product($variable_product);
+		$facebook_product_parent->set_fb_brand('Nike');
+		$facebook_product_parent->save();
+
+		// Get the variation product
+		$variation = wc_get_product($variable_product->get_children()[0]);
+
+		// Create a Facebook product instance for the variation
+		$facebook_product_variation = new \WC_Facebook_Product($variation);
+
+		// Retrieve the brand from the variation
+		$brand = $facebook_product_variation->get_fb_brand();
+		$this->assertEquals($brand, 'Nike');
+
+		// Set a different brand for the variation
+		$facebook_product_variation->set_fb_brand('Adidas');
+		$facebook_product_variation->save();
+
+		// Retrieve the brand again and check if it reflects the new value
+		$brand = $facebook_product_variation->get_fb_brand();
+		$this->assertEquals($brand, 'Adidas');
+	}
 }


### PR DESCRIPTION
Changes proposed in this Pull Request:

This PR introduces a new feature to the Facebook WooCommerce Plugin, allowing users to add a brand field to their products. With this update, we can seamlessly synchronize the brand field with the Facebook Commerce Manager platform.

<img width="989" alt="Screenshot 2024-10-30 at 18 08 06" src="https://github.com/user-attachments/assets/0efc54f9-88f1-487e-881b-300bd203a3dd">
<img width="527" alt="Screenshot 2024-10-30 at 18 08 36" src="https://github.com/user-attachments/assets/d0cf9ae0-293b-4685-a033-643dc6214a1f">
