### PR TITLE
Update catalog link to navigate to correct tab in Commerc…

### DIFF
--- a/tests/Unit/ConnectionTest.php
+++ b/tests/Unit/ConnectionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace WooCommerce\Facebook\Tests\Unit;
+
+use WooCommerce\Facebook\Admin\Settings_Screens\Connection;
+
+class ConnectionTest extends \WP_UnitTestCase {
+
+    private $connection;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->connection = new Connection();
+    }
+
+    public function testGetCatalogUrl(): void {
+        $catalog_id = '123456' ;
+        $business_id = '789012';
+        
+        $expected_url = "https://www.facebook.com/commerce/catalogs/{$catalog_id}/products/?business_id={$business_id}";
+        
+        // Use reflection to access private method
+        $method = new \ReflectionMethod(Connection::class, 'get_catalog_url');
+        $method->setAccessible(true);
+        
+        $actual_url = $method->invoke($this->connection, $catalog_id, $business_id);
+        
+        $this->assertEquals($expected_url, $actual_url);
+    }
+
+    public function testGetCatalogUrlWithoutBusinessId(): void {
+        $catalog_id = '123456';
+        
+        $expected_url = "https://facebook.com/products/catalog/{$catalog_id}";
+        
+        // Use reflection to access private method
+        $method = new \ReflectionMethod(Connection::class, 'get_catalog_url');
+        $method->setAccessible(true);
+        
+        $actual_url = $method->invoke($this->connection, $catalog_id, '');
+        
+        $this->assertEquals($expected_url, $actual_url);
+    }
+
+    public function testEnqueueAssetsWhenNotOnPage(): void {
+        // Mock is_current_screen_page to return false
+        $connection = $this->getMockBuilder(Connection::class)
+            ->onlyMethods(['is_current_screen_page'])
+            ->getMock();
+        
+        $connection->method('is_current_screen_page')
+            ->willReturn(false);
+            
+        // No styles should be enqueued
+        $connection->enqueue_assets();
+        
+        $this->assertFalse(wp_style_is('wc-facebook-admin-connection-settings'));
+    }
+
+    public function testGetSettings(): void {
+        $settings = $this->connection->get_settings();
+        
+        $this->assertIsArray($settings);
+        $this->assertNotEmpty($settings);
+        
+        // Check that the settings array has the expected structure
+        $this->assertArrayHasKey('type', $settings[0]);
+        $this->assertEquals('title', $settings[0]['type']);
+        
+        // Check debug mode setting
+        $debug_setting = $settings[1];
+        $this->assertEquals('checkbox', $debug_setting['type']);
+        $this->assertEquals('no', $debug_setting['default']);
+        
+        // Check feed generator setting
+        $feed_setting = $settings[2];
+        $this->assertEquals('checkbox', $feed_setting['type']);
+        $this->assertEquals('no', $feed_setting['default']);
+    }
+}


### PR DESCRIPTION
## Changelog Entry

### Fix
- Update catalog link in Connections tab to navigate to Catalog tab instead of Overview.

### Description
This pull request fixes an issue where the catalog link in the Connections tab navigates to the Overview page instead of the Catalog tab. The fix updates the link to point to the correct location, ensuring that users are directed to the intended page.

### Changes
- Updated the catalog link in the Connections tab to navigate to the Catalog tab.
- Ensured that the link points to the correct location, resolving the navigation issue.

### Screenshots
![Screenshot 2024-11-22 at 13 19 49](https://github.com/user-attachments/assets/5bef12e9-ee25-4ebc-a4f3-b17283c65c9d)
<img width="1716" alt="Screenshot 2024-11-22 at 13 21 24" src="https://github.com/user-attachments/assets/2571da92-7d38-4c95-84ee-690826d54209">


### Detailed Test Instructions
1. Navigate to the Connections tab.
2. Click on the catalog link.
3. Verify that the link directs you to the Catalog tab instead of the Overview page.

### Additional Details
This fix resolves a navigation issue and ensures that users are directed to the correct page when clicking on the catalog link in the Connections tab.