### PR TITLE
T208550935: refactor: simplify onboarding by removing empty tab navig…

### DIFF
--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -62,18 +62,20 @@ class Settings {
 	 * @since 3.0.7
 	 */
 	private function build_menu_item_array( bool $is_connected ): array {
+
+		if ( ! $is_connected ) {
+			return [ Settings_Screens\Advertise::ID => new Settings_Screens\Advertise() ];
+		}
+
 		$advertise  = [ Settings_Screens\Advertise::ID => new Settings_Screens\Advertise() ];
 		$connection = [ Settings_Screens\Connection::ID => new Settings_Screens\Connection() ];
-
-		$first = ( $is_connected ) ? $advertise : $connection;
-		$last  = ( $is_connected ) ? $connection : $advertise;
 
 		$screens = array(
 			Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
 			Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
 		);
 
-		return array_merge( array_merge( $first, $screens ), $last );
+		return array_merge( $advertise, $screens, $connection );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes [T208550935](https://www.internalfb.com/intern/tasks/?t=208550935)

Simplify the onboarding experience by removing unnecessary UI elements:
- Remove empty tab navigation
- Keep only the essential onboarding card
- Improve first-time user experience clarity
- Remove empty state displays

### Screenshots:

<details>
<summary>Before</summary>
<img width="923" alt="Screenshot 2024-11-22 at 16 44 44" src="https://github.com/user-attachments/assets/ecbbd62d-6ac2-4031-8d1e-850c0dc52564">

</details>

<details>
<summary>After</summary>
<img width="996" alt="Screenshot 2024-11-22 at 16 45 11" src="https://github.com/user-attachments/assets/627beaad-c115-4516-ba46-a3a4c5554ab4">

</details>

### Detailed test instructions:

1. Install and activate the plugin as a new user
2. Navigate to the plugin's main page
3. Verify only the onboarding card is visible without tab navigation
4. Complete the onboarding flow to ensure it works as expected

### Additional details:

This change addresses several UX issues:
- Eliminates confusion from empty tabs
- Streamlines the first-time user experience
- Removes outdated design elements
- Focuses user attention on essential onboarding steps

### Changelog entry

> Update - Streamline onboarding UI by removing empty tab navigation and focusing on core onboarding experience